### PR TITLE
Add invoice download option

### DIFF
--- a/amazonorders/cli.py
+++ b/amazonorders/cli.py
@@ -195,9 +195,14 @@ Order History for {year}{optional_start_index}{optional_full_details}
 
         if kwargs["invoices"]:
             for o in orders:
-                invoice_path = os.path.join(config.output_dir, f"{o.order_id}.pdf")
-                amazon_orders.download_invoice(o.order_id, invoice_path, o.invoice_link)
-                click.echo(f"Invoice saved to {invoice_path}")
+                file_paths = amazon_orders.download_invoice(
+                    o.order_id,
+                    o.order_date,
+                    config.output_dir,
+                    o.invoice_link,
+                )
+                for p in file_paths:
+                    click.echo(f"Invoice saved to {p}")
 
         if kwargs["csv"]:
             # Convert list of dataclass‐like objects into a list of dicts
@@ -326,31 +331,6 @@ def order(ctx: Context,
         o = amazon_orders.get_order(order_id)
 
         click.echo(f"{_order_output(o, config)}\n")
-    except AmazonOrdersError as e:
-        logger.debug("An error occurred.", exc_info=True)
-        ctx.fail(str(e))
-
-
-@amazon_orders_cli.command()
-@click.pass_context
-@click.argument("order_id")
-@click.option("--output-file", help="Where to write the invoice PDF.")
-def invoice(ctx: Context, order_id: str, output_file: Optional[str]) -> None:
-    """Download the invoice PDF for a given Amazon order ID."""
-    amazon_session = ctx.obj["amazon_session"]
-
-    try:
-        _authenticate(amazon_session)
-
-        config = ctx.obj["conf"]
-        amazon_orders = AmazonOrders(amazon_session, config=config)
-
-        if not output_file:
-            output_file = f"{order_id}.pdf"
-
-        invoice_link = f"{config.constants.ORDER_INVOICE_MENU_URL}?orderId={order_id}"
-        amazon_orders.download_invoice(order_id, output_file, invoice_link)
-        click.echo(f"Invoice saved to {output_file}\n")
     except AmazonOrdersError as e:
         logger.debug("An error occurred.", exc_info=True)
         ctx.fail(str(e))

--- a/amazonorders/cli.py
+++ b/amazonorders/cli.py
@@ -196,7 +196,7 @@ Order History for {year}{optional_start_index}{optional_full_details}
         if kwargs["invoices"]:
             for o in orders:
                 invoice_path = os.path.join(config.output_dir, f"{o.order_id}.pdf")
-                amazon_orders.download_invoice(o.order_id, invoice_path)
+                amazon_orders.download_invoice(o.order_id, invoice_path, o.invoice_link)
                 click.echo(f"Invoice saved to {invoice_path}")
 
         if kwargs["csv"]:
@@ -348,7 +348,8 @@ def invoice(ctx: Context, order_id: str, output_file: Optional[str]) -> None:
         if not output_file:
             output_file = f"{order_id}.pdf"
 
-        amazon_orders.download_invoice(order_id, output_file)
+        invoice_link = f"{config.constants.ORDER_INVOICE_MENU_URL}?orderId={order_id}"
+        amazon_orders.download_invoice(order_id, output_file, invoice_link)
         click.echo(f"Invoice saved to {output_file}\n")
     except AmazonOrdersError as e:
         logger.debug("An error occurred.", exc_info=True)

--- a/amazonorders/constants.py
+++ b/amazonorders/constants.py
@@ -45,6 +45,7 @@ class Constants:
     ORDER_HISTORY_URL = f"{BASE_URL}/your-orders/orders"
     ORDER_DETAILS_URL = f"{BASE_URL}/gp/your-account/order-details"
     ORDER_INVOICE_URL = f"{BASE_URL}/gp/css/summary/print.html"
+    ORDER_INVOICE_MENU_URL = f"{BASE_URL}/gp/shared-cs/ajax/invoice/invoice.html"
     HISTORY_FILTER_QUERY_PARAM = "timeFilter"
 
     ##########################################################################

--- a/amazonorders/constants.py
+++ b/amazonorders/constants.py
@@ -44,6 +44,7 @@ class Constants:
 
     ORDER_HISTORY_URL = f"{BASE_URL}/your-orders/orders"
     ORDER_DETAILS_URL = f"{BASE_URL}/gp/your-account/order-details"
+    ORDER_INVOICE_URL = f"{BASE_URL}/gp/css/summary/print.html"
     HISTORY_FILTER_QUERY_PARAM = "timeFilter"
 
     ##########################################################################

--- a/amazonorders/entity/order.py
+++ b/amazonorders/entity/order.py
@@ -175,7 +175,7 @@ class Order(Parsable):
                         value = None
 
         if not value and self.order_id:
-            value = f"{self.config.constants.ORDER_INVOICE_URL}?orderID={self.order_id}"
+            value = f"{self.config.constants.ORDER_INVOICE_MENU_URL}?orderId={self.order_id}"
 
         return value
 

--- a/amazonorders/orders.py
+++ b/amazonorders/orders.py
@@ -189,7 +189,15 @@ class AmazonOrders:
 
         if invoice_link and "invoice.html" in invoice_link:
             menu_response = self.amazon_session.get(invoice_link)
-            link_tag = util.select_one(menu_response.parsed, self.config.selectors.FIELD_ORDER_INVOICE_PDF_LINK_SELECTOR)
+            link_tag = util.select_one(
+                menu_response.parsed,
+                self.config.selectors.FIELD_ORDER_INVOICE_PDF_LINK_SELECTOR,
+            )
+            if not link_tag:
+                link_tag = util.select_one(
+                    menu_response.parsed,
+                    self.config.selectors.FIELD_ORDER_INVOICE_PRINT_LINK_SELECTOR,
+                )
             if link_tag:
                 invoice_url = link_tag.get("href")
                 if invoice_url and not invoice_url.startswith("http"):

--- a/amazonorders/orders.py
+++ b/amazonorders/orders.py
@@ -188,6 +188,8 @@ class AmazonOrders:
         invoice_url = None
 
         if invoice_link and "invoice.html" in invoice_link:
+            if not invoice_link.startswith("http"):
+                invoice_link = f"{self.config.constants.BASE_URL}{invoice_link}"
             menu_response = self.amazon_session.get(invoice_link)
             link_tag = util.select_one(
                 menu_response.parsed,
@@ -208,6 +210,9 @@ class AmazonOrders:
                 invoice_url = invoice_link
             else:
                 invoice_url = f"{self.config.constants.ORDER_INVOICE_URL}?orderID={order_id}"
+
+        if invoice_url and not invoice_url.startswith("http"):
+            invoice_url = f"{self.config.constants.BASE_URL}{invoice_url}"
 
         response = self.amazon_session.get(invoice_url, headers={"Accept": "application/pdf"})
         if response.response.status_code != 200:

--- a/amazonorders/selectors.py
+++ b/amazonorders/selectors.py
@@ -117,6 +117,7 @@ class Selectors:
         "a[href*='/gp/digital/your-account/order-summary.html']",
     ]
     FIELD_ORDER_INVOICE_POPOVER_SELECTOR = "span[data-a-popover*='invoice.html']"
+    FIELD_ORDER_INVOICE_PDF_LINK_SELECTOR = "a[href*='print']"
     FIELD_ORDER_NUMBER_SELECTOR = ["[data-component='orderId']",
                                    "[data-component='briefOrderInfo'] div.a-column",
                                    ".order-date-invoice-item bdi[dir='ltr']",

--- a/amazonorders/selectors.py
+++ b/amazonorders/selectors.py
@@ -112,6 +112,11 @@ class Selectors:
                                          # Would like to use this or similar, but not yet sure how consistent it is
                                          # ".order-header__header-link-list-item:first-of-type a"
                                          ]
+    FIELD_ORDER_INVOICE_LINK_SELECTOR = [
+        "a[href*='/gp/css/summary/print.html']",
+        "a[href*='/gp/digital/your-account/order-summary.html']",
+    ]
+    FIELD_ORDER_INVOICE_POPOVER_SELECTOR = "span[data-a-popover*='invoice.html']"
     FIELD_ORDER_NUMBER_SELECTOR = ["[data-component='orderId']",
                                    "[data-component='briefOrderInfo'] div.a-column",
                                    ".order-date-invoice-item bdi[dir='ltr']",

--- a/amazonorders/selectors.py
+++ b/amazonorders/selectors.py
@@ -117,7 +117,8 @@ class Selectors:
         "a[href*='/gp/digital/your-account/order-summary.html']",
     ]
     FIELD_ORDER_INVOICE_POPOVER_SELECTOR = "span[data-a-popover*='invoice.html']"
-    FIELD_ORDER_INVOICE_PDF_LINK_SELECTOR = "a[href*='print']"
+    FIELD_ORDER_INVOICE_PDF_LINK_SELECTOR = "a[href$='invoice.pdf']"
+    FIELD_ORDER_INVOICE_PRINT_LINK_SELECTOR = "a[href*='print']"
     FIELD_ORDER_NUMBER_SELECTOR = ["[data-component='orderId']",
                                    "[data-component='briefOrderInfo'] div.a-column",
                                    ".order-date-invoice-item bdi[dir='ltr']",

--- a/tests/entity/test_order.py
+++ b/tests/entity/test_order.py
@@ -29,6 +29,21 @@ class TestOrder(UnitTestCase):
         self.assertIsNone(order.subscription_discount)
         self.assertEqual(order.grand_total, 7777.99)
 
+    def test_order_invoice_link(self):
+        # GIVEN
+        with open(
+            os.path.join(self.RESOURCES_DIR, "orders", "order-currency-stripped-snippet.html"),
+            "r",
+            encoding="utf-8",
+        ) as f:
+            parsed = BeautifulSoup(f.read(), self.test_config.bs4_parser)
+
+        # WHEN
+        order = Order(parsed, self.test_config, full_details=True)
+
+        # THEN
+        self.assertIn("/gp/css/summary/print.html", order.invoice_link)
+
     def test_order_promotion_applied(self):
         # GIVEN
         with open(os.path.join(self.RESOURCES_DIR, "orders", "order-promotion-applied-snippet.html"),

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -139,49 +139,6 @@ class TestCli(UnitTestCase):
             self.assertIn("max_auth_attempts: 7", f.read())
 
     @responses.activate
-    def test_invoice_command(self):
-        # GIVEN
-        order_id = "112-2961628-4757846"
-        self.given_login_responses_success()
-        pdf_link = "/documents/download/abc123/invoice.pdf"
-        responses.add(
-            responses.GET,
-            f"{self.test_config.constants.ORDER_INVOICE_MENU_URL}?orderId={order_id}",
-            body=f"<a href='{pdf_link}'>Invoice 1</a>",
-            status=200,
-        )
-        responses.add(
-            responses.GET,
-            f"{self.test_config.constants.BASE_URL}{pdf_link}",
-            body=b"PDFDATA",
-            status=200,
-            content_type="application/pdf",
-        )
-
-        # WHEN
-        with self.runner.isolated_filesystem():
-            output_file = "invoice.pdf"
-            response = self.runner.invoke(
-                amazon_orders_cli,
-                [
-                    "--config-path",
-                    self.test_config.config_path,
-                    "--username",
-                    "some-username",
-                    "--password",
-                    "some-password",
-                    "invoice",
-                    order_id,
-                    "--output-file",
-                    output_file,
-                ],
-            )
-
-            # THEN
-            self.assertEqual(0, response.exit_code)
-            self.assertTrue(os.path.exists(output_file))
-
-    @responses.activate
     def test_history_command_download_invoices(self):
         # GIVEN
         year = 2024
@@ -238,4 +195,5 @@ class TestCli(UnitTestCase):
 
             # THEN
             self.assertEqual(0, response.exit_code)
-            self.assertTrue(os.path.exists(f"{order_id}.pdf"))
+            expected = "AmazonInvoice_20241101_112-5939971-8962610.pdf"
+            self.assertTrue(os.path.exists(expected))

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -145,6 +145,12 @@ class TestCli(UnitTestCase):
         self.given_login_responses_success()
         responses.add(
             responses.GET,
+            f"{self.test_config.constants.ORDER_INVOICE_MENU_URL}?orderId={order_id}",
+            body="<a href='/gp/css/summary/print.html?orderID={order_id}'>PDF</a>",
+            status=200,
+        )
+        responses.add(
+            responses.GET,
             f"{self.test_config.constants.ORDER_INVOICE_URL}?orderID={order_id}",
             body=b"PDFDATA",
             status=200,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -143,15 +143,16 @@ class TestCli(UnitTestCase):
         # GIVEN
         order_id = "112-2961628-4757846"
         self.given_login_responses_success()
+        pdf_link = "/documents/download/abc123/invoice.pdf"
         responses.add(
             responses.GET,
             f"{self.test_config.constants.ORDER_INVOICE_MENU_URL}?orderId={order_id}",
-            body="<a href='/gp/css/summary/print.html?orderID={order_id}'>PDF</a>",
+            body=f"<a href='{pdf_link}'>Invoice 1</a>",
             status=200,
         )
         responses.add(
             responses.GET,
-            f"{self.test_config.constants.ORDER_INVOICE_URL}?orderID={order_id}",
+            f"{self.test_config.constants.BASE_URL}{pdf_link}",
             body=b"PDFDATA",
             status=200,
             content_type="application/pdf",
@@ -198,9 +199,16 @@ class TestCli(UnitTestCase):
                 body=f.read(),
                 status=200,
             )
+        pdf_link = "/documents/download/def456/invoice.pdf"
         responses.add(
             responses.GET,
-            f"{self.test_config.constants.ORDER_INVOICE_URL}?orderID={order_id}",
+            f"{self.test_config.constants.ORDER_INVOICE_MENU_URL}?orderId={order_id}",
+            body=f"<a href='{pdf_link}'>Invoice 1</a>",
+            status=200,
+        )
+        responses.add(
+            responses.GET,
+            f"{self.test_config.constants.BASE_URL}{pdf_link}",
             body=b"PDFDATA",
             status=200,
             content_type="application/pdf",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -137,3 +137,91 @@ class TestCli(UnitTestCase):
         self.assertIn("max_auth_attempts\" updated", response.output)
         with open(self.test_config.config_path, "r") as f:
             self.assertIn("max_auth_attempts: 7", f.read())
+
+    @responses.activate
+    def test_invoice_command(self):
+        # GIVEN
+        order_id = "112-2961628-4757846"
+        self.given_login_responses_success()
+        responses.add(
+            responses.GET,
+            f"{self.test_config.constants.ORDER_INVOICE_URL}?orderID={order_id}",
+            body=b"PDFDATA",
+            status=200,
+            content_type="application/pdf",
+        )
+
+        # WHEN
+        with self.runner.isolated_filesystem():
+            output_file = "invoice.pdf"
+            response = self.runner.invoke(
+                amazon_orders_cli,
+                [
+                    "--config-path",
+                    self.test_config.config_path,
+                    "--username",
+                    "some-username",
+                    "--password",
+                    "some-password",
+                    "invoice",
+                    order_id,
+                    "--output-file",
+                    output_file,
+                ],
+            )
+
+            # THEN
+            self.assertEqual(0, response.exit_code)
+            self.assertTrue(os.path.exists(output_file))
+
+    @responses.activate
+    def test_history_command_download_invoices(self):
+        # GIVEN
+        year = 2024
+        order_id = "112-5939971-8962610"
+        self.given_login_responses_success()
+        self.given_order_history_exists(year)
+        with open(
+            os.path.join(self.RESOURCES_DIR, "orders", f"order-details-{order_id}.html"),
+            "r",
+            encoding="utf-8",
+        ) as f:
+            responses.add(
+                responses.GET,
+                f"{self.test_config.constants.ORDER_DETAILS_URL}?orderID={order_id}",
+                body=f.read(),
+                status=200,
+            )
+        responses.add(
+            responses.GET,
+            f"{self.test_config.constants.ORDER_INVOICE_URL}?orderID={order_id}",
+            body=b"PDFDATA",
+            status=200,
+            content_type="application/pdf",
+        )
+
+        # WHEN
+        with self.runner.isolated_filesystem():
+            response = self.runner.invoke(
+                amazon_orders_cli,
+                [
+                    "--config-path",
+                    self.test_config.config_path,
+                    "--username",
+                    "some-username",
+                    "--password",
+                    "some-password",
+                    "--output-dir",
+                    ".",
+                    "history",
+                    "--year",
+                    year,
+                    "--single-page",
+                    "--full-details",
+                    "--invoices",
+                ],
+            )
+
+            # THEN
+            self.assertEqual(0, response.exit_code)
+            self.assertTrue(os.path.exists(f"{order_id}.pdf"))

--- a/tests/testcase.py
+++ b/tests/testcase.py
@@ -16,6 +16,7 @@ class TestCase(unittest.TestCase):
         self.assertIsNotNone(order.order_id)
         self.assertIsNotNone(order.grand_total)
         self.assertIsNotNone(order.order_details_link)
+        self.assertIsNotNone(order.invoice_link)
         self.assertIsNotNone(order.order_date)
         if order.recipient:
             self.assertIsNotNone(order.recipient.name)


### PR DESCRIPTION
## Summary
- expose `--invoices` flag on `history` command
- parse invoice popover URLs from order pages
- fetch PDF invoices for each order when the flag is used
- test invoice downloads during history retrieval

## Testing
- `make test` *(fails: Could not install virtualenv)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'responses')*

------
https://chatgpt.com/codex/tasks/task_b_684743b81d788330902d5f09487a3ba6