### PR TITLE
Use transactions as the data driver

### DIFF
--- a/amazonorders/cli.py
+++ b/amazonorders/cli.py
@@ -184,17 +184,41 @@ Order History for {year}{optional_start_index}{optional_full_details}
         config = ctx.obj["conf"]
         amazon_orders = AmazonOrders(amazon_session,
                                      config=config)
+        amazon_transactions = AmazonTransactions(amazon_session,
+                                                 config=config)
 
         start_time = time.time()
         # total = 0
 
-        orders = amazon_orders.get_order_history(year=kwargs["year"],
-                                                 start_index=kwargs["start_index"],
-                                                 full_details=kwargs["full_details"],
-                                                 keep_paging=not kwargs["single_page"])
+        orders = amazon_orders.get_order_history(
+            year=kwargs["year"],
+            start_index=kwargs["start_index"],
+            full_details=kwargs["full_details"],
+            keep_paging=not kwargs["single_page"],
+        )
+
+        order_map = {o.order_id: o for o in orders}
+
+        transactions = amazon_transactions.get_transactions_by_year(year)
+
+        fetch_orders = kwargs["full_details"] or kwargs["csv"] or kwargs["invoices"]
+
+        for t in transactions:
+            order = order_map.get(t.order_id)
+            if fetch_orders and not order:
+                order = amazon_orders.get_order(t.order_id)
+            if order:
+                order.payment_date = t.completed_date
+                order.payment_amount = t.grand_total
+                if t.payment_method:
+                    order.payment_method = t.payment_method
+                t.order = order
 
         if kwargs["invoices"]:
-            for o in orders:
+            for t in transactions:
+                o = t.order
+                if not o:
+                    continue
                 file_paths = amazon_orders.download_invoice(
                     o.order_id,
                     o.order_date,
@@ -207,15 +231,17 @@ Order History for {year}{optional_start_index}{optional_full_details}
         if kwargs["csv"]:
             # Convert list of dataclass‐like objects into a list of dicts
             orders_dict = []
-            for o in orders:
-                if o.payment_amount not in (0, None):
-                    order_dict = o.__dict__.copy()
-                    # Format dates as yyyy/mm/dd
-                    if isinstance(o.order_date, datetime.date):
-                        order_dict["order_date"] = o.order_date.strftime("%Y/%m/%d")
-                    if isinstance(o.payment_date, datetime.date):
-                        order_dict["payment_date"] = o.payment_date.strftime("%Y/%m/%d")
-                    orders_dict.append(order_dict)
+            for t in transactions:
+                o = t.order
+                if not o or o.payment_amount in (0, None):
+                    continue
+                order_dict = o.__dict__.copy()
+                # Format dates as yyyy/mm/dd
+                if isinstance(o.order_date, datetime.date):
+                    order_dict["order_date"] = o.order_date.strftime("%Y/%m/%d")
+                if isinstance(o.payment_date, datetime.date):
+                    order_dict["payment_date"] = o.payment_date.strftime("%Y/%m/%d")
+                orders_dict.append(order_dict)
 
             # Convert list of dataclass‐like objects into a list of dicts
             df = pd.DataFrame(orders_dict)
@@ -292,20 +318,26 @@ Order History for {year}{optional_start_index}{optional_full_details}
 
             # Export to CSV (no index column)
             df.to_csv(
-                f"orders-{kwargs['year']}.csv",
+                f"transactions-{kwargs['year']}.csv",
                 index=False,
                 quoting=csv.QUOTE_MINIMAL,
             )  # quote fields with commas
         else:
-            for o in orders:
-                click.echo(f"{_order_output(o, config)}\n")
+            for t in transactions:
+                if t.order:
+                    click.echo(f"{_order_output(t.order, config)}\n")
+                else:
+                    click.echo(f"{_transaction_output(t, config)}\n")
 
-        total = len(orders)
+        total = len(transactions)
         end_time = time.time()
 
         click.echo(
-            "... {total} orders parsed in {time} seconds.\n".format(total=total,
-                                                                    time=int(end_time - start_time)))
+            "... {total} transactions parsed in {time} seconds.\n".format(
+                total=total,
+                time=int(end_time - start_time),
+            )
+        )
     except AmazonOrdersError as e:
         logger.debug("An error occurred.", exc_info=True)
         ctx.fail(str(e))
@@ -340,6 +372,12 @@ def order(ctx: Context,
 @click.pass_context
 @click.option("--days", default=365,
               help="The number of days of transactions to get.")
+@click.option("--full-details", is_flag=True, default=False,
+              help="Get the full details for each transaction's order. This will execute an additional request per Order.")
+@click.option("--csv", is_flag=True, default=False,
+              help="Export the transaction history to a CSV file.")
+@click.option("--invoices", is_flag=True, default=False,
+              help="Download an invoice PDF for each transaction's order.")
 def transactions(ctx: Context, **kwargs: Any):
     """
     Get Amazon transaction history for a given number of days.
@@ -361,12 +399,140 @@ Transaction History for {days} days
         config = ctx.obj["conf"]
         amazon_transactions = AmazonTransactions(amazon_session,
                                                  config=config)
+        amazon_orders = AmazonOrders(amazon_session,
+                                     config=config)
 
         start_time = time.time()
-        total = 0
-        for t in amazon_transactions.get_transactions(days=days):
-            click.echo(f"{_transaction_output(t, config)}\n")
-            total += 1
+
+        transactions = amazon_transactions.get_transactions(days=days)
+
+        fetch_orders = kwargs["full_details"] or kwargs["csv"] or kwargs["invoices"]
+        if fetch_orders:
+            for t in transactions:
+                order = amazon_orders.get_order(t.order_id)
+                order.payment_date = t.completed_date
+                order.payment_amount = t.grand_total
+                if t.payment_method:
+                    order.payment_method = t.payment_method
+                t.order = order
+
+            if kwargs["invoices"]:
+                for t in transactions:
+                    o = t.order
+                    if not o:
+                        continue
+                    file_paths = amazon_orders.download_invoice(
+                        o.order_id,
+                        o.order_date,
+                        config.output_dir,
+                        o.invoice_link,
+                    )
+                    for p in file_paths:
+                        click.echo(f"Invoice saved to {p}")
+
+            if kwargs["csv"]:
+                orders_dict = []
+                for t in transactions:
+                    o = t.order
+                    if not o or o.payment_amount in (0, None):
+                        continue
+                    order_dict = o.__dict__.copy()
+                    if isinstance(o.order_date, datetime.date):
+                        order_dict["order_date"] = o.order_date.strftime("%Y/%m/%d")
+                    if isinstance(o.payment_date, datetime.date):
+                        order_dict["payment_date"] = o.payment_date.strftime("%Y/%m/%d")
+                    orders_dict.append(order_dict)
+
+                df = pd.DataFrame(orders_dict)
+
+                df = df.rename(
+                    columns={
+                        "index": "Index",
+                        "order_date": "Order Date",
+                        "order_id": "Order ID",
+                        "item_quantity": "Item quantity",
+                        "item_subtotal": "Item subtotal",
+                        "item_shipping_and_handling": "Item shipping and handling",
+                        "item_promotion": "Item promotion",
+                        "item_federal_tax": "Item Federal Tax",
+                        "item_provincial_tax": "Item Provincial Tax",
+                        "item_regulatory_fee": "Item Regulatory Fee",
+                        "item_net_total": "Item net total",
+                        "payment_method": "Payment Method",
+                        "payment_method_last_4": "Payment Method Last 4",
+                        "payment_reference_id": "Payment Reference ID",
+                        "payment_date": "Payment date",
+                        "payment_amount": "Payment amount",
+                        "shipments": "Shipments",
+                        "title": "Title",
+                        "amazon_internal_product_category": "Amazon Internal Product Category",
+                        "amazon_class": "Class",
+                        "amazon_commodity": "Commodity",
+                        "items": "Items",
+                        "order_details_link": "Order Details Link",
+                        "grand_total": "Grand Total",
+                        "recipient": "Recipient",
+                        "free_shipping": "Free Shipping",
+                        "coupon_savings": "Coupon Savings",
+                        "subscription_discount": "Subscription Discount",
+                        "total_before_tax": "Total Before Tax",
+                        "estimated_tax": "Estimated Tax",
+                        "refund_total": "Refund Total",
+                    }
+                )[
+                    [
+                        "Index",
+                        "Order Date",
+                        "Order ID",
+                        "Item quantity",
+                        "Item subtotal",
+                        "Item shipping and handling",
+                        "Item promotion",
+                        "Item Federal Tax",
+                        "Item Provincial Tax",
+                        "Item Regulatory Fee",
+                        "Item net total",
+                        "Payment Method",
+                        "Payment Method Last 4",
+                        "Payment Reference ID",
+                        "Payment date",
+                        "Payment amount",
+                        "Shipments",
+                        "Title",
+                        "Amazon Internal Product Category",
+                        "Class",
+                        "Commodity",
+                        "Items",
+                        "Order Details Link",
+                        "Grand Total",
+                        "Recipient",
+                        "Free Shipping",
+                        "Coupon Savings",
+                        "Subscription Discount",
+                        "Total Before Tax",
+                        "Estimated Tax",
+                        "Refund Total",
+                    ]
+                ]
+
+                df.to_csv(
+                    f"transactions-{days}.csv",
+                    index=False,
+                    quoting=csv.QUOTE_MINIMAL,
+                )
+            else:
+                for t in transactions:
+                    if t.order:
+                        click.echo(f"{_order_output(t.order, config)}\n")
+                    else:
+                        click.echo(f"{_transaction_output(t, config)}\n")
+
+            total = len(transactions)
+        else:
+            for t in transactions:
+                click.echo(f"{_transaction_output(t, config)}\n")
+            total = len(transactions)
+
         end_time = time.time()
 
         click.echo(
@@ -491,6 +657,8 @@ Order #{order_id}
     order_str += f"\n  Order Details Link: {o.order_details_link}"
     order_str += f"\n  Grand Total: {config.constants.format_currency(o.grand_total)}"
     order_str += f"\n  Order Placed Date: {o.order_date}"
+    if o.payment_date:
+        order_str += f"\n  Payment Date: {o.payment_date}"
     if o.recipient:
         order_str += f"\n  Recipient: {o.recipient}"
     else:

--- a/amazonorders/constants.py
+++ b/amazonorders/constants.py
@@ -44,6 +44,7 @@ class Constants:
 
     ORDER_HISTORY_URL = f"{BASE_URL}/your-orders/orders"
     ORDER_DETAILS_URL = f"{BASE_URL}/gp/your-account/order-details"
+    ORDER_SUMMARY_URL = f"{BASE_URL}/gp/digital/your-account/order-summary.html"
     ORDER_INVOICE_URL = f"{BASE_URL}/gp/css/summary/print.html"
     ORDER_INVOICE_MENU_URL = f"{BASE_URL}/gp/shared-cs/ajax/invoice/invoice.html"
     HISTORY_FILTER_QUERY_PARAM = "timeFilter"

--- a/amazonorders/entity/transaction.py
+++ b/amazonorders/entity/transaction.py
@@ -10,6 +10,10 @@ from bs4 import Tag
 
 from amazonorders.conf import AmazonOrdersConfig
 from amazonorders.entity.parsable import Parsable
+from typing import Optional, TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover - only for type hints
+    from amazonorders.entity.order import Order
 
 logger = logging.getLogger(__name__)
 
@@ -43,6 +47,8 @@ class Transaction(Parsable):
         self.seller: str = self.safe_simple_parse(
             selector=self.config.selectors.FIELD_TRANSACTION_SELLER_NAME_SELECTOR
         )
+        #: The Order associated with this Transaction, populated on demand.
+        self.order: Optional["Order"] = None
 
     def __repr__(self) -> str:
         return f"<Transaction {self.completed_date}: \"Order #{self.order_id}, Grand Total: {self.grand_total}\">"

--- a/amazonorders/entity/transaction.py
+++ b/amazonorders/entity/transaction.py
@@ -80,7 +80,7 @@ class Transaction(Parsable):
                 "Check if Amazon changed the HTML."
             )  # pragma: no cover
 
-        match = re.match(".*#([0-9-]+)$", value)
+        match = re.match(".*#(D?[0-9-]+)$", value)
         value = match.group(1) if match else ""
 
         return value

--- a/amazonorders/entity/transaction.py
+++ b/amazonorders/entity/transaction.py
@@ -26,8 +26,11 @@ class Transaction(Parsable):
     def __init__(self,
                  parsed: Tag,
                  config: AmazonOrdersConfig,
-                 completed_date: date) -> None:
+                 completed_date: date,
+                 index: Optional[int] = None) -> None:
         super().__init__(parsed, config)
+
+        self.index: Optional[int] = index
 
         #: The Transaction completed date.
         self.completed_date: date = completed_date

--- a/amazonorders/orders.py
+++ b/amazonorders/orders.py
@@ -45,7 +45,8 @@ class AmazonOrders:
             logger.setLevel(logging.DEBUG)
 
     def get_order(self,
-                  order_id: str) -> Order:
+                  order_id: str,
+                  current_index: Optional[int] = None) -> Order:
         """
         Get the full details for a given Amazon order ID.
 
@@ -72,7 +73,7 @@ class AmazonOrders:
 
         order_details_tag = util.select_one(order_details_response.parsed,
                                             self.config.selectors.ORDER_DETAILS_ENTITY_SELECTOR)
-        order: Order = self.config.order_cls(order_details_tag, self.config, full_details=True)
+        order: Order = self.config.order_cls(order_details_tag, self.config, full_details=True, index=current_index)
 
         return order
 

--- a/amazonorders/orders.py
+++ b/amazonorders/orders.py
@@ -60,8 +60,15 @@ class AmazonOrders:
         if order_details_response.response.url.startswith(self.config.constants.SIGN_IN_URL):
             self.amazon_session.raise_expired_session()
 
-        if not order_details_response.response.url.startswith(self.config.constants.ORDER_DETAILS_URL):
-            raise AmazonOrdersNotFoundError(f"Amazon redirected, which likely means Order {order_id} was not found.")
+        if not order_details_response.response.url.startswith(
+            (
+                self.config.constants.ORDER_DETAILS_URL,
+                self.config.constants.ORDER_SUMMARY_URL,
+            )
+        ):
+            raise AmazonOrdersNotFoundError(
+                f"Amazon redirected, which likely means Order {order_id} was not found."
+            )
 
         order_details_tag = util.select_one(order_details_response.parsed,
                                             self.config.selectors.ORDER_DETAILS_ENTITY_SELECTOR)

--- a/amazonorders/transactions.py
+++ b/amazonorders/transactions.py
@@ -127,3 +127,9 @@ class AmazonTransactions:
                 keep_paging = False
 
         return transactions
+
+    def get_transactions_by_year(self, year: int) -> List[Transaction]:
+        """Get Amazon transaction history for the given year."""
+        days = (datetime.date.today() - datetime.date(year, 1, 1)).days + 365
+        transactions = self.get_transactions(days=days)
+        return [t for t in transactions if t.completed_date.year == year]

--- a/amazonorders/transactions.py
+++ b/amazonorders/transactions.py
@@ -130,6 +130,6 @@ class AmazonTransactions:
 
     def get_transactions_by_year(self, year: int) -> List[Transaction]:
         """Get Amazon transaction history for the given year."""
-        days = (datetime.date.today() - datetime.date(year, 1, 1)).days + 365
+        days = (datetime.date.today() - datetime.date(year, 1, 1)).days + 30
         transactions = self.get_transactions(days=days)
         return [t for t in transactions if t.completed_date.year == year]

--- a/amazonorders/transactions.py
+++ b/amazonorders/transactions.py
@@ -95,6 +95,8 @@ class AmazonTransactions:
 
         min_date = datetime.date.today() - datetime.timedelta(days=days)
 
+        current_index = 0
+
         transactions: List[Transaction] = []
         keep_paging = True
         next_page_data = None
@@ -118,7 +120,9 @@ class AmazonTransactions:
 
             for transaction in loaded_transactions:
                 if transaction.completed_date >= min_date:
+                    transaction.index = current_index
                     transactions.append(transaction)
+                    current_index += 1
                 else:
                     next_page_data = None
                     break

--- a/tests/resources/orders/order-summary-D01-9262519-8073835.html
+++ b/tests/resources/orders/order-summary-D01-9262519-8073835.html
@@ -1,0 +1,3136 @@
+<!doctype html><html lang="en-ca" class="a-no-js" data-19ax5a9jf="dingo"><!-- sp:feature:head-start -->
+<head><script>var aPageStart = (new Date()).getTime();</script><meta charset="utf-8"/>
+<!-- sp:end-feature:head-start -->
+<!-- sp:feature:csm:head-open-part1 -->
+
+<script type='text/javascript'>var ue_t0=ue_t0||+new Date();</script>
+<!-- sp:end-feature:csm:head-open-part1 -->
+<!-- sp:feature:cs-optimization -->
+<meta http-equiv='x-dns-prefetch-control' content='on'>
+<link rel="preconnect" href="https://images-na.ssl-images-amazon.com" crossorigin>
+<link rel="preconnect" href="https://m.media-amazon.com" crossorigin>
+<!-- sp:end-feature:cs-optimization -->
+<!-- sp:feature:csm:head-open-part2 -->
+<script type='text/javascript'>
+window.ue_ihb = (window.ue_ihb || window.ueinit || 0) + 1;
+if (window.ue_ihb === 1) {
+
+var ue_csm = window,
+    ue_hob = +new Date();
+(function(d){var e=d.ue=d.ue||{},f=Date.now||function(){return+new Date};e.d=function(b){return f()-(b?0:d.ue_t0)};e.stub=function(b,a){if(!b[a]){var c=[];b[a]=function(){c.push([c.slice.call(arguments),e.d(),d.ue_id])};b[a].replay=function(b){for(var a;a=c.shift();)b(a[0],a[1],a[2])};b[a].isStub=1}};e.exec=function(b,a){return function(){try{return b.apply(this,arguments)}catch(c){ueLogError(c,{attribution:a||"undefined",logLevel:"WARN"})}}}})(ue_csm);
+
+
+    var ue_err_chan = 'jserr-rw';
+(function(d,e){function h(f,b){if(!(a.ec>a.mxe)&&f){a.ter.push(f);b=b||{};var c=f.logLevel||b.logLevel;c&&c!==k&&c!==m&&c!==n&&c!==p||a.ec++;c&&c!=k||a.ecf++;b.pageURL=""+(e.location?e.location.href:"");b.logLevel=c;b.attribution=f.attribution||b.attribution;a.erl.push({ex:f,info:b})}}function l(a,b,c,e,g){d.ueLogError({m:a,f:b,l:c,c:""+e,err:g,fromOnError:1,args:arguments},g?{attribution:g.attribution,logLevel:g.logLevel}:void 0);return!1}var k="FATAL",m="ERROR",n="WARN",p="DOWNGRADED",a={ec:0,ecf:0,
+pec:0,ts:0,erl:[],ter:[],buffer:[],mxe:50,startTimer:function(){a.ts++;setInterval(function(){d.ue&&a.pec<a.ec&&d.uex("at");a.pec=a.ec},1E4)}};l.skipTrace=1;h.skipTrace=1;h.isStub=1;d.ueLogError=h;d.ue_err=a;e.onerror=l})(ue_csm,window);
+
+
+var ue_id = 'D32ZY1PB3E90Y6D0E1G7',
+    ue_url = '/rd/uedata',
+    ue_navtiming = 1,
+    ue_mid = 'A2EUQ1WTGCTBG2',
+    ue_sid = '133-7199711-5876416',
+    ue_sn = 'www.amazon.ca',
+    ue_furl = 'fls-na.amazon.ca',
+    ue_surl = 'https://unagi-na.amazon.com/1/events/com.amazon.csm.nexusclient.prod',
+    ue_int = 0,
+    ue_fcsn = 1,
+    ue_urt = 3,
+    ue_rpl_ns = 'cel-rpl',
+    ue_ddq = 1,
+    ue_fpf = '//fls-na.amazon.ca/1/batch/1/OP/A2EUQ1WTGCTBG2:133-7199711-5876416:D32ZY1PB3E90Y6D0E1G7$uedata=s:',
+    ue_sbuimp = 1,
+    ue_ibft = 0,
+    ue_sswmts = 0,
+    ue_jsmtf = 0,
+    ue_fnt = 0,
+    ue_lpsi = 6000,
+    ue_lob = '1',
+    ue_sjslob = 0,
+    ue_dsbl_cel = 1,
+
+    ue_swi = 1;
+var ue_viz=function(){(function(b,f,d){function g(){return(!(p in d)||0<d[p])&&(!(q in d)||0<d[q])}function h(c){if(b.ue.viz.length<w&&!r){var a=c.type;c=c.originalEvent;/^focus./.test(a)&&c&&(c.toElement||c.fromElement||c.relatedTarget)||(a=g()?f[s]||("blur"==a||"focusout"==a?t:u):t,b.ue.viz.push(a+":"+(+new Date-b.ue.t0)),a==u&&(b.ue.isl&&x("at"),r=1))}}for(var r=0,x=b.uex,a,k,l,s,v=["","webkit","o","ms","moz"],e=0,m=1,u="visible",t="hidden",p="innerWidth",q="innerHeight",w=20,n=0;n<v.length&&!e;n++)if(a=
+v[n],k=(a?a+"H":"h")+"idden",e="boolean"==typeof f[k])l=a+"visibilitychange",s=(a?a+"V":"v")+"isibilityState";h({});e&&f.addEventListener(l,h,0);m=g()?1:0;d.addEventListener("resize",function(){var a=g()?1:0;m!==a&&(m=a,h({}))},{passive:!0});b.ue&&e&&(b.ue.pageViz={event:l,propHid:k})})(ue_csm,ue_csm.document,ue_csm.window)};window.ue_viz=ue_viz;
+
+(function(d,h,O){function I(a){return a&&a.replace&&a.replace(/^\s+|\s+$/g,"")}function v(a){return"undefined"===typeof a}function D(a,b){for(var c in b)b[w](c)&&(a[c]=b[c])}function J(a){try{var b=O.cookie.match(RegExp("(^| )"+a+"=([^;]+)"));if(b)return b[2].trim()}catch(c){}}function P(m,b,c){var p=(z||{}).type;if("device"!==c||2!==p&&1!==p)m&&(d.ue_id=a.id=a.rid=m,x&&(x=x.replace(/((.*?:){2})(\w+)/,function(a,b){return b+m})),F&&(e("id",F,m),F=0)),b&&(x&&(x=x.replace(/(.*?:)(\w|-)+/,function(a,
+c){return c+b})),d.ue_sid=b),c&&a.tag("page-source:"+c),d.ue_fpf=x}function Q(){var a={};return function(b){b&&(a[b]=1);b=[];for(var c in a)a[w](c)&&b.push(c);return b}}function A(d,b,c,p){p=p||+new G;var f,l;if(b||v(c)){if(d)for(l in f=b?e("t",b)||e("t",b,{}):a.t,f[d]=p,c)c[w](l)&&e(l,b,c[l]);return p}}function e(d,b,c){var e=b&&b!=a.id?a.sc[b]:a;e||(e=a.sc[b]={});"id"===d&&c&&(R=1);return e[d]=c||e[d]}function S(d,b,c,e,f){c="on"+c;var l=b[c];"function"===typeof l?d&&(a.h[d]=l):l=function(){};b[c]=
+function(a){f?(e(a),l(a)):(l(a),e(a))};b[c]&&(b[c].isUeh=1)}function T(m,b,c,p){function q(b,c){var d=[b],g=0,f={},l,h;c?(d.push("m=1"),f[c]=1):f=a.sc;for(h in f)if(f[w](h)){var p=e("wb",h),k=e("t",h)||{},n=e("t0",h)||a.t0,q;if(c||2==p){p=p?g++:"";d.push("sc"+p+"="+h);for(q in k)v(k[q])||null===k[q]||d.push(q+p+"="+(k[q]-n));d.push("t"+p+"="+k[m]);if(e("ctb",h)||e("wb",h))l=1}}!y&&l&&d.push("ctb=1");return d.join("&")}function l(b,c,g,e,m){if(b){var f=d.ue_err;d.ue_url&&!e&&!m&&b&&0<b.length&&(e=
+new Image,a.iel.push(e),e.src=b,a.count&&a.count("postbackImageSize",b.length));x?(m=h.encodeURIComponent)&&b&&(e=new Image,b=""+d.ue_fpf+m(b)+":"+(+new G-d.ue_t0),a.iel.push(e),e.src=b):a.log&&(a.log(b,"uedata",{n:1}),a.ielf.push(b));f&&!f.ts&&f.startTimer();a.b&&(f=a.b,a.b="",l(f,c,g,1))}}function s(b){var c=z?z.type:B,d=2==c||a.isBFonMshop,c=c&&!d,e=a.bfini;if(!R||a.isBFCache)e&&1<e&&(b+="&bfform=1",c||(a.isBFT=e-1)),d&&(b+="&bfnt=1",a.isBFT=a.isBFT||1),a.ssw&&a.isBFT&&(a.isBFonMshop&&(a.isNRBF=
+0),v(a.isNRBF)&&(d=a.ssw(a.oid),d.e||v(d.val)||(a.isNRBF=1<d.val?0:1)),v(a.isNRBF)||(b+="&nrbf="+a.isNRBF)),a.isBFT&&!a.isNRBF&&(b+="&bft="+a.isBFT);return b}if(!a.paused&&(b||v(c))){for(var k in c)c[w](k)&&e(k,b,c[k]);a.isBFonMshop||A("pc",b,c);k="ld"===m&&b&&e("wb",b);var t=e("id",b)||a.id;k||t===a.oid||(F=b,ca(t,(e("t",b)||{}).tc||+e("t0",b),+e("t0",b),K?e("pty",b):B,K?e("spty",b):B));var t=e("id",b)||a.id,u=e("id2",b),g=a.url+"?"+m+"&v="+a.v+"&id="+t,y=e("ctb",b)||e("wb",b),C;y&&(g+="&ctb="+y);
+u&&(g+="&id2="+u);1<d.ueinit&&(g+="&ic="+d.ueinit);if(!("ld"!=m&&"ul"!=m||b&&b!=t)){if("ld"==m){try{h[L]&&h[L].isUeh&&(h[L]=null)}catch(J){}if(h.chrome)for(u=0;u<M.length;u++)U(H,M[u]);(u=O.ue_backdetect)&&u.ue_back&&u.ue_back.value++;d._uess&&(C=d._uess());a.isl=1}a._bf&&(g+="&bf="+a._bf());d.ue_navtiming&&f&&(e("ctb",t,"1"),a.isBFonMshop||A("tc",B,B,N));!E||a.isBFonMshop||V||(f&&D(a.t,{na_:f.navigationStart,ul_:f.unloadEventStart,_ul:f.unloadEventEnd,rd_:f.redirectStart,_rd:f.redirectEnd,fe_:f.fetchStart,
+lk_:f.domainLookupStart,_lk:f.domainLookupEnd,co_:f.connectStart,_co:f.connectEnd,sc_:f.secureConnectionStart,rq_:f.requestStart,rs_:f.responseStart,_rs:f.responseEnd,dl_:f.domLoading,di_:f.domInteractive,de_:f.domContentLoadedEventStart,_de:f.domContentLoadedEventEnd,_dc:f.domComplete,ld_:f.loadEventStart,_ld:f.loadEventEnd,ntd:("function"!==typeof E.now||v(N)?0:new G(N+E.now())-new G)+a.t0}),z&&D(a.t,{ty:z.type+a.t0,rc:z.redirectCount+a.t0}),V=1);a.isBFonMshop||D(a.t,{hob:d.ue_hob,hoe:d.ue_hoe});
+a.ifr&&(g+="&ifr=1")}A(m,b,c,p);var r,n;k||b&&b!==t||da(b);(c=d.ue_mbl)&&c.cnt&&!k&&(g+=c.cnt());k?e("wb",b,2):"ld"==m&&(a.lid=I(t));for(r in a.sc)if(1==e("wb",r))break;if(k){if(a.s)return;g=q(g,null)}else c=q(g,null),c!=g&&(c=s(c),a.b=c),C&&(g+=C),g=q(g,b||a.id);g=s(g);if(a.b||k)for(r in a.sc)2==e("wb",r)&&delete a.sc[r];C=0;a._rt&&(g+="&rt="+a._rt());c=h.csa;if(!k&&c)for(n in r=e("t",b)||{},c=c("PageTiming"),r)r[w](n)&&c("mark",ea[n]||n,r[n]);k||(a.s=0,(n=d.ue_err)&&0<n.ec&&n.pec<n.ec&&(n.pec=n.ec,
+g+="&ec="+n.ec+"&ecf="+n.ecf),C=e("ctb",b),"ld"!==m||b||a.markers?a.markers&&a.isl&&!k&&b&&D(a.markers,e("t",b)):(a.markers={},D(a.markers,e("t",b))),e("t",b,{}));a.tag&&a.tag().length&&(g+="&csmtags="+a.tag().join("|"),a.tag=Q());n=a.viz||[];(r=n.length)&&(g+="&viz="+n.splice(0,r).join("|"));v(d.ue_pty)||(g+="&pty="+d.ue_pty+"&spty="+d.ue_spty+"&pti="+d.ue_pti);a.tabid&&(g+="&tid="+a.tabid);a.aftb&&(g+="&aftb=1");!a._ui||b&&b!=t||(g+=a._ui());g+="&lob="+(d.ue_lob||"0");a.a=g;l(g,m,C,k,b&&"string"===
+typeof b&&-1!==b.indexOf("csa:"))}}function da(a){var b=h.ue_csm_markers||{},c;for(c in b)b[w](c)&&A(c,a,B,b[c])}function y(a,b,c){c=c||h;if(c[W])c[W](a,b,!1);else if(c[X])c[X]("on"+a,b)}function U(a,b,c){c=c||h;if(c[Y])c[Y](a,b,!1);else if(c[Z])c[Z]("on"+a,b)}function $(){function a(){d.onUl()}function b(a){return function(){c[a]||(c[a]=1,T(a))}}var c={},e,f;d.onLd=b("ld");d.onLdEnd=b("ld");d.onUl=b("ul");e={stop:b("os")};h.chrome?(y(H,a),M.push(a)):e[H]=d.onUl;for(f in e)e[w](f)&&S(0,h,f,e[f]);
+d.ue_viz&&ue_viz();y("load",d.onLd);A("ue")}function ca(e,b,c,f,q){var l=d.ue_mbl,s=h.csa,k=s&&s("SPA"),s=s&&s("PageTiming");l&&l.ajax&&l.ajax(b,c);k&&s&&(e={requestId:e,transitionType:"soft"},K&&("string"===typeof f&&(e.pageType=f,d.ue_pty=f),"string"===typeof q&&(e.subPageType=q,d.ue_spty=q)),k("newPage",e),s("mark","transitionStart",b));a.tag("ajax-transition")}d.ueinit=(d.ueinit||0)+1;var a=d.ue=d.ue||{};a.t0=h.aPageStart||d.ue_t0;a.id=d.ue_id;a.url=d.ue_url;a.rid=d.ue_id;a.a="";a.b="";a.h={};
+a.s=1;a.t={};a.sc={};a.iel=[];a.ielf=[];a.viz=[];a.v="0.314666.0";a.paused=!1;var w="hasOwnProperty",H="beforeunload",L="on"+H,W="addEventListener",Y="removeEventListener",X="attachEvent",Z="detachEvent",ea={cf:"criticalFeature",af:"aboveTheFold",fn:"functional",fp:"firstPaint",fcp:"firstContentfulPaint",bb:"bodyBegin",be:"bodyEnd",ld:"loaded"},G=h.Date,E=h.performance||h.webkitPerformance,f=(E||{}).timing,z=(E||{}).navigation,N=(f||{}).navigationStart,x=d.ue_fpf,R=0,V=0,M=[],F=0,K=d.ue_a2ptyl,B;
+a.oid=I(a.id);a.lid=I(a.id);a._t0=a.t0;a.tag=Q();a.ifr=h.top!==h.self||h.frameElement?1:0;a.markers=null;a.attach=y;a.detach=U;if("000-0000000-8675309"===d.ue_sid){var aa=J("cdn-rid"),ba=J("session-id");aa&&ba&&P(aa,ba,"cdn")}d.uei=$;d.ueh=S;d.ues=e;d.uet=A;d.uex=T;a.reset=P;a.pause=function(d){a.paused=d};$()})(ue_csm,ue_csm.window,ue_csm.document);
+
+
+ue.stub(ue,"event");ue.stub(ue,"onSushiUnload");ue.stub(ue,"onSushiFlush");
+
+ue.stub(ue,"log");ue.stub(ue,"onunload");ue.stub(ue,"onflush");
+(function(b){function f(){var a={requestId:b.ue_id||"rid",server:b.ue_sn||"sn",obfuscatedMarketplaceId:b.ue_mid||"mid"};b.ue_sjslob&&(a.lob=b.ue_lob||"0");return a}var a=b.ue;a.cv={};a.cv.scopes={};a.cv.buffer=[];a.count=function(b,d,c){var e=a.cv;a.d();c&&c.scope&&(e=a.cv.scopes[c.scope]=a.cv.scopes[c.scope]||{});if(void 0===d)return e[b];e[b]=d;a.cv.buffer.push({c:b,v:d})};a.count("baselineCounter2",1);a&&a.event&&(a.event(f(),"csm","csm.CSMBaselineEvent.4"),a.count("nexusBaselineCounter",1,{bf:1}))})(ue_csm);
+
+
+
+var ue_hoe = +new Date();
+}
+window.ueinit = window.ue_ihb;
+</script>
+
+<!-- 9m19afev8ku4g8afz766w -->
+<script>window.ue && ue.count && ue.count('CSMLibrarySize', 10133)</script>
+<!-- sp:end-feature:csm:head-open-part2 -->
+<!-- sp:feature:aui-assets -->
+<link rel="stylesheet" href="https://m.media-amazon.com/images/I/11EIQ5IGqaL._RC|01ZTHTZObnL.css,41juX+nXGEL.css,31hZWJWyh-L.css,11D3BPoiHRL.css,01qDClimA1L.css,01s-u+zGGeL.css,413Vvv3GONL.css,11TIuySqr6L.css,01Rw4F+QU6L.css,11JJsNcqOIL.css,01J3raiFJrL.css,01IdKcBuAdL.css,014QJx7nWqL.css,01qV08ntX5L.css,01otFnpIi0L.css,01l+IElyGxL.css,21mJbqB3V3L.css,01A3iq2zPSL.css,01cOTp-rwoL.css,01Sv7-fQIGL.css,51ADEjpKc0L.css,01XPHJk60-L.css,01mDpfE6qDL.css,11ChJlzZQoL.css,01UgxIH-BSL.css,01fxuupJToL.css,21izvssjRGL.css,01oATFSeEjL.css,21RWaJb6t+L.css,11nzUs9fQtL.css,21Pm+fi9a+L.css,01CFUgsA-YL.css,31q12zQLu7L.css,11-tILsHNJL.css,11qXt6W2PSL.css,11PDZ29p-PL.css,11nH79VWt-L.css,11tNhCU--0L.css,11msBd9oOTL.css,11BO1RWH3kL.css,01ELGsSvEzL.css,21uCqPYVxrL.css,21vyqs8q4vL.css,01vfkVAfcLL.css,215Q9RsWvdL.css,11-w3ouFc1L.css,11hvENnYNUL.css,11Qek6G6pNL.css,01890+Vwk8L.css,01X7ObkctzL.css,014VAMpg+ZL.css,01qiwJ7qDfL.css,21TAMzcrOKL.css,016mfgi+D2L.css,01eniAikTiL.css,215U6Luo5rL.css,013-xYw+SRL.css_.css?AUIClients/AmazonUI#not-trident.1092656-T1.1072613-T1.1186350-T1.1186361-T2.1186360-T2.1213305-T2" />
+<script>
+(function(b,a,c,d){if((b=b.AmazonUIPageJS||b.P)&&b.when&&b.register){c=[];for(a=a.currentScript;a;a=a.parentElement)a.id&&c.push(a.id);return b.log("A copy of P has already been loaded on this page.","FATAL",c.join(" "))}})(window,document,Date);(function(a,b,c,d){"use strict";a._pSetI=function(){return null}})(window,document,Date);(function(d,I,K,L){"use strict";d._sw=function(){var p;return function(w,g,u,B,h,C,q,k,x,y){p||(p=!0,y.execute("RetailPageServiceWorker",function(){function z(a,b){e.controller&&a?(a={feature:"retail_service_worker_messaging",command:a},b&&(a.data=b),e.controller.postMessage(a)):a&&h("sw:sw_message_no_ctrl",1)}function p(a){var b=a.data;if(b&&"retail_service_worker_messaging"===b.feature&&b.command&&b.data){var c=b.data;a=d.ue;var f=d.ueLogError;switch(b.command){case "log_counter":a&&k(a.count)&&
+c.name&&a.count(c.name,0===c.value?0:c.value||1);break;case "log_tag":a&&k(a.tag)&&c.tag&&(a.tag(c.tag),b=d.uex,a.isl&&k(b)&&b("at"));break;case "log_error":f&&k(f)&&c.message&&f({message:c.message,logLevel:c.level||"ERROR",attribution:c.attribution||"RetailServiceWorker"});break;case "log_weblab_trigger":if(!c.weblab||!c.treatment)break;a&&k(a.trigger)?a.trigger(c.weblab,c.treatment):(h("sw:wt:miss"),h("sw:wt:miss:"+c.weblab+":"+c.treatment));break;default:h("sw:unsupported_message_command",1)}}}
+function v(a,b){return"sw:"+(b||"")+":"+a+":"}function D(a,b){e.register("/service-worker.js").then(function(){h(a+"success")}).catch(function(c){y.logError(c,"[AUI SW] Failed to "+b+" service worker: ","ERROR","RetailPageServiceWorker");h(a+"failure")})}function E(){l.forEach(function(a){q(a)})}function n(a){return a.capabilities.isAmazonApp&&a.capabilities.android}function F(a,b,c){if(b)if(b.mshop&&n(a))a=v(c,"mshop_and"),b=b.mshop.action,l.push(a+"supported"),b(a,c);else if(b.browser){a=u(/Chrome/i)&&
+!u(/Edge/i)&&!u(/OPR/i)&&!a.capabilities.isAmazonApp&&!u(new RegExp(B+"bwv"+B+"b"));var f=b.browser;b=v(c,"browser");a?(a=f.action,l.push(b+"supported"),a(b,c)):l.push(b+"unsupported")}}function G(a,b,c){a&&l.push(v("register",c)+"unsupported");b&&l.push(v("unregister",c)+"unsupported");E()}try{var e=navigator.serviceWorker}catch(a){q("sw:nav_err")}(function(){if(e){var a=function(){z("page_loaded",{rid:d.ue_id,mid:d.ue_mid,pty:d.ue_pty,sid:d.ue_sid,spty:d.ue_spty,furl:d.ue_furl})};x(e,"message",
+p);z("client_messaging_ready");y.when("load").execute(a);x(e,"controllerchange",function(){z("client_messaging_ready");"complete"===I.readyState&&a()})}})();var l=[],m=function(a,b){var c=d.uex,f=d.uet;a=g(":","aui","sw",a);"ld"===b&&k(c)?c("ld",a,{wb:1}):k(f)&&f(b,a,{wb:1})},J=function(a,b,c){function f(a){b&&k(b.failure)&&b.failure(a)}function H(){l=setTimeout(function(){q(g(":","sw:"+r,t.TIMED_OUT));f({ok:!1,statusCode:t.TIMED_OUT,done:!1});m(r,"ld")},c||4E3)}var t={NO_CONTROLLER:"no_ctrl",TIMED_OUT:"timed_out",
+UNSUPPORTED_BROWSER:"unsupported_browser",UNEXPECTED_RESPONSE:"unexpected_response"},r=g(":",a.feature,a.command),l,n=!0;if("MessageChannel"in d&&e&&"controller"in e)if(e.controller){var p=new MessageChannel;p.port1.onmessage=function(c){(c=c.data)&&c.feature===a.feature&&c.command===a.command?(n&&(m(r,"cf"),n=!1),m(r,"af"),clearTimeout(l),c.done||H(),c.ok?b&&k(b.success)&&b.success(c):f(c),c.done&&m(r,"ld")):h(g(":","sw:"+r,t.UNEXPECTED_RESPONSE),1)};H();m(r,"bb");e.controller.postMessage(a,[p.port2])}else q(g(":",
+"sw:"+a.feature,t.NO_CONTROLLER)),f({ok:!1,statusCode:t.NO_CONTROLLER,done:!0});else q(g(":","sw:"+a.feature,t.UNSUPPORTED_BROWSER)),f({ok:!1,statusCode:t.UNSUPPORTED_BROWSER,done:!0})};(function(){e?(m("ctrl_changed","bb"),e.addEventListener("controllerchange",function(){q("sw:ctrl_changed");m("ctrl_changed","ld")})):h(g(":","sw:ctrl_changed","sw_unsupp"),1)})();(function(){var a=function(){m(b,"ld");var a=d.uex;J({feature:"page_proxy",command:"request_feature_tags"},{success:function(b){b=b.data;
+Array.isArray(b)&&b.forEach(function(a){"string"===typeof a?q(g(":","sw:ppft",a)):h(g(":","sw:ppft","invalid_tag"),1)});h(g(":","sw:ppft","success"),1);C&&C.isl&&k(a)&&a("at")},failure:function(a){h(g(":","sw:ppft","error:"+(a.statusCode||"ppft_error")),1)}})};if("requestIdleCallback"in d){var b=g(":","ppft","callback_ricb");d.requestIdleCallback(a,{timeout:1E3})}else b=g(":","ppft","callback_timeout"),setTimeout(a,0);m(b,"bb")})();var A={reg:{},unreg:{}};A.reg.mshop={action:D};A.reg.browser={action:D};
+(function(a){var b=a.reg,c=a.unreg;e&&e.getRegistrations?(w.when("A").execute(function(b){if((a.reg.mshop||a.unreg.mshop)&&"function"===typeof n&&n(b)){var f=a.reg.mshop?"T1":"C",e=d.ue;e&&e.trigger?e.trigger("MSHOP_SW_CLIENT_446196",f):h("sw:mshop:wt:failed")}F(b,c,"unregister")}),x(d,"load",function(){w.when("A").execute(function(a){F(a,b,"register");E()})})):(G(b&&b.browser,c&&c.browser,"browser"),w.when("A").execute(function(a){"function"===typeof n&&n(a)&&G(b&&b.mshop,c&&c.mshop,"mshop_and")}))})(A)}))}}()})(window,
+document,Date);(function(c,e,I,B){"use strict";c._pd=function(){var a,u;return function(C,f,h,k,b,D,v,E,F){function w(d){try{return d()}catch(J){return!1}}function l(){if(m){var d={w:c.innerWidth||b.clientWidth,h:c.innerHeight||b.clientHeight};5<Math.abs(d.w-q.w)||50<d.h-q.h?(q=d,n=4,(d=a.mobile||a.tablet?450<d.w&&d.w>d.h:1250<=d.w)?k(b,"a-ws"):b.className=v(b,"a-ws")):0<n&&(n--,x=setTimeout(l,16))}}function G(d){(m=d===B?!m:!!d)&&l()}function H(){return m}if(!u){u=!0;var r=function(){var d=["O","ms","Moz","Webkit"],
+c=e.createElement("div");return{testGradients:function(){return!0},test:function(a){var b=a.charAt(0).toUpperCase()+a.substr(1);a=(d.join(b+" ")+b+" "+a).split(" ");for(b=a.length;b--;)if(""===c.style[a[b]])return!0;return!1},testTransform3d:function(){return!0}}}(),y=b.className,z=/(^| )a-mobile( |$)/.test(y),A=/(^| )a-tablet( |$)/.test(y);a={audio:function(){return!!e.createElement("audio").canPlayType},video:function(){return!!e.createElement("video").canPlayType},canvas:function(){return!!e.createElement("canvas").getContext},
+svg:function(){return!!e.createElementNS&&!!e.createElementNS("http://www.w3.org/2000/svg","svg").createSVGRect},offline:function(){return navigator.hasOwnProperty&&navigator.hasOwnProperty("onLine")&&navigator.onLine},dragDrop:function(){return"draggable"in e.createElement("span")},geolocation:function(){return!!navigator.geolocation},history:function(){return!(!c.history||!c.history.pushState)},webworker:function(){return!!c.Worker},autofocus:function(){return"autofocus"in e.createElement("input")},
+inputPlaceholder:function(){return"placeholder"in e.createElement("input")},textareaPlaceholder:function(){return"placeholder"in e.createElement("textarea")},localStorage:function(){return"localStorage"in c&&null!==c.localStorage},orientation:function(){return"orientation"in c},touch:function(){return"ontouchend"in e},gradients:function(){return r.testGradients()},hires:function(){var a=c.devicePixelRatio&&1.5<=c.devicePixelRatio||c.matchMedia&&c.matchMedia("(min-resolution:144dpi)").matches;E("hiRes"+
+(z?"Mobile":A?"Tablet":"Desktop"),a?1:0);return a},transform3d:function(){return r.testTransform3d()},touchScrolling:function(){return f(/Windowshop|android|OS ([5-9]|[1-9][0-9]+)(_[0-9]{1,2})+ like Mac OS X|SOFTWARE=([5-9]|[1-9][0-9]+)(.[0-9]{1,2})+.*DEVICE=iPhone|Chrome|Silk|Firefox|Trident.+?; Touch/i)},ios:function(){return f(/OS [1-9][0-9]*(_[0-9]*)+ like Mac OS X/i)&&!f(/trident|Edge/i)},android:function(){return f(/android.([1-9]|[L-Z])/i)&&!f(/trident|Edge/i)},mobile:function(){return z},
+tablet:function(){return A},rtl:function(){return"rtl"===b.dir}};for(var g in a)a.hasOwnProperty(g)&&(a[g]=w(a[g]));for(var t="textShadow textStroke boxShadow borderRadius borderImage opacity transform transition".split(" "),p=0;p<t.length;p++)a[t[p]]=w(function(){return r.test(t[p])});var m=!0,x=0,q={w:0,h:0},n=4;l();h(c,"resize",function(){clearTimeout(x);n=4;l()});b.className=v(b,"a-no-js");k(b,"a-js");!f(/OS [1-8](_[0-9]*)+ like Mac OS X/i)||c.navigator.standalone||f(/safari/i)||k(b,"a-ember");
+h=[];for(g in a)a.hasOwnProperty(g)&&a[g]&&h.push("a-"+g.replace(/([A-Z])/g,function(a){return"-"+a.toLowerCase()}));k(b,h.join(" "));b.setAttribute("data-aui-build-date",F);C.register("p-detect",function(){return{capabilities:a,localStorage:a.localStorage&&D,toggleResponsiveGrid:G,responsiveGridEnabled:H}});return a||{}}}}()})(window,document,Date);(function(g,l,C,D){function E(a){n&&n.tag&&n.tag(p(":","aui",a))}function m(a,b){n&&n.count&&n.count("aui:"+a,0===b?0:b||(n.count("aui:"+a)||0)+1)}function F(a){try{return a.test(navigator.userAgent)}catch(b){return!1}}function G(a){return"function"===typeof a}function u(a,b,c){a.addEventListener?a.addEventListener(b,c,!1):a.attachEvent&&a.attachEvent("on"+b,c)}function p(a,b,c,f){b=b&&c?b+a+c:b||c;return f?p(a,b,f):b}function y(a,b,c){try{Object.defineProperty(a,b,{value:c,writable:!1})}catch(f){a[b]=
+c}return c}function O(a,b){a.className=P(a,b)+" "+b}function P(a,b){return(" "+a.className+" ").split(" "+b+" ").join(" ").replace(/^ | $/g,"")}function ca(a,b,c){var f=c=a.length,e=function(){f--||(H.push(b),I||(q?q.set(z):setTimeout(z,0),I=!0))};for(e();c--;)Q[a[c]]?e():(v[a[c]]=v[a[c]]||[]).push(e)}function da(a,b,c,f,e){var d=l.createElement(a?"script":"link");u(d,"error",f);e&&u(d,"load",e);a?(d.type="text/javascript",d.async=!0,c&&/AUIClients|images[/]I/.test(b)&&d.setAttribute("crossorigin",
+"anonymous"),d.src=b):(d.rel="stylesheet",d.href=b);l.getElementsByTagName("head")[0].appendChild(d)}function R(a,b){return function(c,f){function e(){da(b,c,d,function(b){J?m("resource_unload"):d?(d=!1,m("resource_retry"),e()):(m("resource_error"),a.log("Asset failed to load: "+c));b&&b.stopPropagation?b.stopPropagation():g.event&&(g.event.cancelBubble=!0)},f)}if(S[c])return!1;S[c]=!0;m("resource_count");var d=!0;return!e()}}function ea(a,b,c){for(var f={name:a,guard:function(c){return b.guardFatal(a,
+c)},guardTime:function(a){return b.guardTime(a)},logError:function(c,d,e){b.logError(c,d,e,a)}},e=[],d=0;d<c.length;d++)A.hasOwnProperty(c[d])&&(e[d]=K.hasOwnProperty(c[d])?K[c[d]](A[c[d]],f):A[c[d]]);return e}function w(a,b,c,f,e){return function(d,k){function n(){var a=null;f?a=k:G(k)&&(q.start=r(),a=k.apply(g,ea(d,h,l)),q.end=r());if(b){A[d]=a;a=d;for(Q[a]=!0;(v[a]||[]).length;)v[a].shift()();delete v[a]}q.done=!0}var h=e||this;G(d)&&(k=d,d=D);b&&(d=d?d.replace(T,""):"__NONAME__",L.hasOwnProperty(d)&&
+h.error(p(", reregistered by ",p(" by ",d+" already registered",L[d]),h.attribution),d),L[d]=h.attribution);for(var l=[],m=0;m<a.length;m++)l[m]=a[m].replace(T,"");var q=x[d||"anon"+ ++fa]={depend:l,registered:r(),namespace:h.namespace};d&&ha.hasOwnProperty(d);c?n():ca(l,h.guardFatal(d,n),d);return{decorate:function(a){K[d]=h.guardFatal(d,a)}}}}function U(a){return function(){var b=Array.prototype.slice.call(arguments);return{execute:w(b,!1,a,!1,this),register:w(b,!0,a,!1,this)}}}function M(a,b){return function(c,
+f){f||(f=c,c=D);var e=this.attribution;return function(){h.push(b||{attribution:e,name:c,logLevel:a});var d=f.apply(this,arguments);h.pop();return d}}}function B(a,b){this.load={js:R(this,!0),css:R(this)};y(this,"namespace",b);y(this,"attribution",a)}function V(){l.body?k.trigger("a-bodyBegin"):setTimeout(V,20)}"use strict";var t=C.now=C.now||function(){return+new C},r=function(a){return a&&a.now?a.now.bind(a):t}(g.performance),ia=r(),ha={},n=g.ue;E();E("aui_build_date:3.25.3-2025-06-09");var W={getItem:function(a){try{return g.localStorage.getItem(a)}catch(b){}},
+setItem:function(a,b){try{return g.localStorage.setItem(a,b)}catch(c){}}},q=g._pSetI(),H=[],ja=[],I=!1,ka=navigator.scheduling&&"function"===typeof navigator.scheduling.isInputPending;var z=function(){for(var a=q?q.set(z):setTimeout(z,0),b=t();ja.length||H.length;)if(H.shift()(),q&&ka){if(150<t()-b&&!navigator.scheduling.isInputPending()||50<t()-b&&navigator.scheduling.isInputPending())return}else if(50<t()-b)return;q?q.clear(a):clearTimeout(a);I=!1};var Q={},v={},S={},J=!1;u(g,"beforeunload",function(){J=
+!0;setTimeout(function(){J=!1},1E4)});var T=/^prv:/,L={},A={},K={},x={},fa=0,X=String.fromCharCode(92),h=[],Y=!0,Z=g.onerror;g.onerror=function(a,b,c,f,e){e&&"object"===typeof e||(e=Error(a,b,c),e.columnNumber=f,e.stack=b||c||f?p(X,e.message,"at "+p(":",b,c,f)):D);var d=h.pop()||{};e.attribution=p(":",e.attribution||d.attribution,d.name);e.logLevel=d.logLevel;e.attribution&&console&&console.log&&console.log([e.logLevel||"ERROR",a,"thrown by",e.attribution].join(" "));h=[];Z&&(d=[].slice.call(arguments),
+d[4]=e,Z.apply(g,d))};B.prototype={logError:function(a,b,c,f){b={message:b,logLevel:c||"ERROR",attribution:p(":",this.attribution,f)};if(g.ueLogError)return g.ueLogError(a||b,a?b:null),!0;console&&console.error&&(console.log(b),console.error(a));return!1},error:function(a,b,c,f){a=Error(p(":",f,a,c));a.attribution=p(":",this.attribution,b);throw a;},guardError:M(),guardFatal:M("FATAL"),guardCurrent:function(a){var b=h[h.length-1];return b?M(b.logLevel,b).call(this,a):a},guardTime:function(a){var b=
+h[h.length-1],c=b&&b.name;return c&&c in x?function(){var b=r(),e=a.apply(this,arguments);x[c].async=(x[c].async||0)+r()-b;return e}:a},log:function(a,b,c){return this.logError(null,a,b,c)},declare:w([],!0,!0,!0),register:w([],!0),execute:w([]),AUI_BUILD_DATE:"3.25.3-2025-06-09",when:U(),now:U(!0),trigger:function(a,b,c){var f=t();this.declare(a,{data:b,pageElapsedTime:f-(g.aPageStart||NaN),triggerTime:f});c&&c.instrument&&N.when("prv:a-logTrigger").execute(function(b){b(a)})},handleTriggers:function(){this.log("handleTriggers deprecated")},
+attributeErrors:function(a){return new B(a)},_namespace:function(a,b){return new B(a,b)},setPriority:function(a){Y?Y=!1:this.log("setPriority only accept the first call.")}};var k=y(g,"AmazonUIPageJS",new B);var N=k._namespace("PageJS","AmazonUI");N.declare("prv:p-debug",x);k.declare("p-recorder-events",[]);k.declare("p-recorder-stop",function(){});y(g,"P",k);V();if(l.addEventListener){var aa;l.addEventListener("DOMContentLoaded",aa=function(){k.trigger("a-domready");l.removeEventListener("DOMContentLoaded",
+aa,!1)},!1)}var ba=l.documentElement,la=g._pd(k,F,u,O,ba,W,P,m,"3.25.3-2025-06-09");F(/UCBrowser/i)||la.localStorage&&O(ba,W.getItem("a-font-class"));k.declare("a-event-revised-handling",!1);g._sw(N,p,F,X,m,n,E,G,u,k);k.declare("a-fix-event-off",!1);m("pagejs:pkgExecTime",r()-ia)})(window,document,Date);
+'use strict';(function(b){function q(a,e,d){function g(a,b,c){var f=Array(e.length);~l&&(f[l]={});~m&&(f[m]=c);for(c=0;c<n.length;c++){var g=n[c],h=a[c];f[g]=h}for(c=0;c<p.length;c++)g=p[c],h=b[c],f[g]=h;a=d.apply(null,f);return~l?f[l]:a}"string"!==typeof a&&b.P.error("C001");-1===a.indexOf("@")&&-1<a.indexOf("/")&&(-1<a.indexOf("es3")||-1<a.indexOf("evergreen"))&&(a=a.substring(0,a.lastIndexOf("/")));if(!r[a]){r[a]=!0;d||(d=e,e=[]);a=a.split(":",2);var c=a[1]?a[0]:void 0,f=(a[1]||a[0]).replace(/@capability\//,
+"@c/"),k=c?b.P._namespace(c):b.P,t=!f.lastIndexOf("@c/",0),u=!f.lastIndexOf("@m/",0),n=[];a=[];var p=[],v=[],m=-1,l=-1;for(c=0;c<e.length;c++){var h=e[c];"module"===h&&k.error("C002");"exports"===h?l=c:"require"===h?m=c:h.lastIndexOf("@p/",0)?h.lastIndexOf("@c/",0)&&h.lastIndexOf("@m/",0)?(n.push(c),a.push("mix:"+h)):(p.push(c),v.push(h)):(n.push(c),a.push(h.substr(3)))}k.when.apply(k,a).register("mix:"+f,function(){var a=[].slice.call(arguments);return t||u||~m||p.length?{capabilities:v,cardModuleFactory:function(b,
+c){b=g(a,b,c);b.P=k;return b},require:~m?q:void 0}:g(a,[],function(){})});(t||u)&&k.when("mix:@amzn/mix.client-runtime","mix:"+f).execute(function(a,b){a.registerCapabilityModule(f,b)});k.when("mix:"+f).register("xcp:"+f,function(a){return a});var q=function(a,b,c){try{var e=-1<f.indexOf("/")?f.split("/")[0]:f,d=a[0],g=d.lastIndexOf("./",0)?d:e+"/"+d.substr(2),h=g.lastIndexOf("@p/",0)?"mix:"+g:g.substr(3);k.when(h).execute(function(a){try{b(a)}catch(x){c(x)}})}catch(w){c(w)}}}}"use strict";var r=
+{};b.mix_d||((b.Promise?P:P.when("3p-promise")).register("@p/promise-is-ready",function(a){b.Promise=b.Promise||a}),(Array.prototype.includes?P:P.when("a-polyfill")).register("@p/polyfill-is-ready",function(){}),b.mix_d=function(a,b,d){P.when("@p/promise-is-ready","@p/polyfill-is-ready").execute("@p/mix-d-deps",function(){q(a,b,d)})},b.xcp_d=b.mix_d,P.when("mix:@amzn/mix.client-runtime").execute(function(a){P.declare("xcp:@xcp/runtime",a)}));b.mixTimeout||(b.mixTimeout=function(a,e,d){b.mixCardInitTimeouts||
+(b.mixCardInitTimeouts={});b.mixCardInitTimeouts[e]&&clearTimeout(b.mixCardInitTimeouts[e]);b.mixCardInitTimeouts[e]=setTimeout(function(){P.log("Client-side initialization timeout","WARN",a)},d)});b.mix_csa_map=b.mix_csa_map||{};b.mix_csa_internal=b.mix_csa_internal||function(a,e,d){return b.mix_csa_map[e]=b.mix_csa_map[e]||b.csa(a,d)};b.mix_csa_internal_key=b.mix_csa_internal_key||function(a,b){for(var d="",e=0;e<b.length;e++){var c=b[e];void 0!==a[c]&&"object"!==typeof a[c]&&(d+=c+":"+a[c]+",")}if(!d)throw Error("bad mix-csa key gen.");
+return d};b.mix_csa_event=b.mix_csa_event||function(a){try{var e=b.mix_csa_internal_key(a,["producerId"])}catch(d){return P.logError(d,"MIX C005","WARN",void 0),function(){}}try{return b.mix_csa_internal("Events",e,a)}catch(d){return P.logError(d,"MIX C004","WARN",e),function(){}}};b.mix_csa=b.mix_csa||function(a,e){try{e=e||"";var d=document.querySelectorAll(a);if(1<d.length)for(var g=0;g<d.length;g++){if(d[g].querySelector(e)){var c=d[g];break}}else 1===d.length&&(c=d[0]);if(!c)throw Error(" ");
+return b.mix_csa_internal("Content",a,{element:c})}catch(f){return P.logError(f,"MIX C004","WARN",a),function(){}}}})(window);
+(window.AmazonUIPageJS ? AmazonUIPageJS : P).when('sp.load.js').execute(function() {
+  (window.AmazonUIPageJS ? AmazonUIPageJS : P).load.js('https://m.media-amazon.com/images/I/61xJcNKKLXL.js?AUIClients/AmazonUIjQuery');
+  (window.AmazonUIPageJS ? AmazonUIPageJS : P).load.js('https://m.media-amazon.com/images/I/11+0JiZJDpL._RC|11Y+5x+kkTL.js,51G4EaNuYYL.js,1194WzDf49L.js,11SmaQaIN9L.js,01OjGWT6e3L.js,01DYUXZnczL.js,21NadQlXUWL.js,01vRf9id2EL.js,11a7qqY8xXL.js,11rRjDLdAVL.js,51C4kaFbiAL.js,11FhdH2HZwL.js,11wb9K3sw0L.js,11BrgrMAHUL.js,11GYEyswV2L.js,210X-JWUe-L.js,01Svfxfy8OL.js,51hrOUe5lOL.js,01ikBbTAneL.js,31KAF--uG1L.js,01qXJuwGmxL.js,01WlsjNmqIL.js,016cEUEBowL.js,11F929pmpYL.js,31vxRYDelFL.js,01rpauTep4L.js,31wjiT+nvTL.js,011FfPwYqHL.js,21vGxgxnRsL.js,014gnDeJDsL.js,11vb6P5C5AL.js,01orqi8e6dL.js_.js?AUIClients/AmazonUI#372963-T1.1072613-T1');
+  (window.AmazonUIPageJS ? AmazonUIPageJS : P).load.js('https://m.media-amazon.com/images/I/51FKj+gURkL.js?AUIClients/CardJsRuntimeBuzzCopyBuild');
+});
+</script>
+<!-- sp:end-feature:aui-assets -->
+<!-- sp:feature:privacy-consent-centralized-prompting -->
+<script>
+  (window.AmazonUIPageJS ? AmazonUIPageJS : P).load.js('https://m.media-amazon.com/images/I/41Bgmk+H0PL.js?AUIClients/PRIVCONAssets-centralized-prompting');
+</script>
+<!-- sp:end-feature:privacy-consent-centralized-prompting -->
+<!-- sp:feature:nav-inline-css -->
+<!-- NAVYAAN CSS -->
+
+<style type="text/css">
+.nav-sprite-v1 .nav-sprite, .nav-sprite-v1 .nav-icon {
+  background-image: url(https://m.media-amazon.com/images/G/15/gno/sprites/nav-sprite-global-1x-reorg-privacy._CB546817341_.png);
+  background-position: 0 1000px;
+  background-repeat: repeat-x;
+}
+.nav-spinner {
+  background-image: url(https://m.media-amazon.com/images/G/15/javascripts/lib/popover/images/snake._CB485935611_.gif);
+  background-position: center center;
+  background-repeat: no-repeat;
+}
+.nav-timeline-icon, .nav-access-image, .nav-timeline-prime-icon {
+  background-image: url(https://m.media-amazon.com/images/G/15/gno/sprites/timeline_sprite_1x._CB439967808_.png);
+  background-repeat: no-repeat;
+}
+</style>
+<link rel="stylesheet" href="https://images-na.ssl-images-amazon.com/images/I/51-Y6keNmXL._RC|71LCBJQTqBL.css,51bZX1Z4-3L.css,31aRZkoapNL.css,01FcI3FsaiL.css,21Hc1s0-E4L.css,31YZpDCYJPL.css,21P0tNl-emL.css,41vWFCvFunL.css,21CB9R4dxNL.css,11INbZw+OPL.css,01H8CHB5aiL.css,21KQnzhmfTL.css,415g7iDx4VL.css_.css?AUIClients/NavDesktopUberAsset#desktop.1197238-T1.1236111-T1.1136183-T1.1167226-T7" />
+<!-- sp:end-feature:nav-inline-css -->
+<!-- sp:feature:host-assets -->
+
+
+
+    
+
+  
+  
+  
+  
+
+
+
+  
+  
+  
+  
+  
+  
+
+  
+
+
+<!-- htmlBeginMarker -->
+        
+
+
+<title>Amazon.ca: Digital Order Summary </title>
+
+
+
+
+
+
+
+
+
+
+<!--&&&Portal&Delimiter&&&--><!-- sp:end-feature:host-assets -->
+<!-- sp:feature:encrypted-slate-token -->
+<meta name='encrypted-slate-token' content='AnYxz3JZE+o4nr4l+fRHdTDLTfyEUnoHQ8EaYcdwrfJWosWM10LCCJ6GlB/kZmgOh6+ccK/sUe/xaiDopUQbNVI8fneQV+nByLK59obKiW0edLZZbAe66QTaBz5Spf33Y7a2hd5G7MRF3bpzTNL87RdH7ZxfLl9G9zdqKkmqaX5Vht5jd414MnlcWSKIxgRp4rOVaZon3HNjqRhtFSroH4vatxoVY2ZKIRxRhNoy/lvuHd/I3+kYKojUTDDDjsp+FzBVMN1CJDokITDbNoAm'>
+<!-- sp:end-feature:encrypted-slate-token -->
+<!-- sp:feature:csm:head-close -->
+<script type='text/javascript'>
+window.ue_ihe = (window.ue_ihe || 0) + 1;
+if (window.ue_ihe === 1) {
+(function(c){c&&1===c.ue_jsmtf&&"object"===typeof c.P&&"function"===typeof c.P.when&&c.P.when("mshop-interactions").execute(function(e){"object"===typeof e&&"function"===typeof e.addListener&&e.addListener(function(b){"object"===typeof b&&"ORIGIN"===b.dataSource&&"number"===typeof b.clickTime&&"object"===typeof b.events&&"number"===typeof b.events.pageVisible&&(c.ue_jsmtf_interaction={pv:b.events.pageVisible,ct:b.clickTime})})})})(ue_csm);
+(function(c,e,b){function m(a){f||(f=d[a.type].id,"undefined"===typeof a.clientX?(h=a.pageX,k=a.pageY):(h=a.clientX,k=a.clientY),2!=f||l&&(l!=h||n!=k)?(r(),g.isl&&e.setTimeout(function(){p("at",g.id)},0)):(l=h,n=k,f=0))}function r(){for(var a in d)d.hasOwnProperty(a)&&g.detach(a,m,d[a].parent)}function s(){for(var a in d)d.hasOwnProperty(a)&&g.attach(a,m,d[a].parent)}function t(){var a="";!q&&f&&(q=1,a+="&ui="+f);return a}var g=c.ue,p=c.uex,q=0,f=0,l,n,h,k,d={click:{id:1,parent:b},mousemove:{id:2,
+parent:b},scroll:{id:3,parent:e},keydown:{id:4,parent:b}};g&&p&&(s(),g._ui=t)})(ue_csm,window,document);
+
+
+(function(s,l){function m(b,e,c){c=c||new Date(+new Date+t);c="expires="+c.toUTCString();n.cookie=b+"="+e+";"+c+";path=/"}function p(b){b+="=";for(var e=n.cookie.split(";"),c=0;c<e.length;c++){for(var a=e[c];" "==a.charAt(0);)a=a.substring(1);if(0===a.indexOf(b))return decodeURIComponent(a.substring(b.length,a.length))}return""}function q(b,e,c){if(!e)return b;-1<b.indexOf("{")&&(b="");for(var a=b.split("&"),f,d=!1,h=!1,g=0;g<a.length;g++)f=a[g].split(":"),f[0]==e?(!c||d?a.splice(g,1):(f[1]=c,a[g]=
+f.join(":")),h=d=!0):2>f.length&&(a.splice(g,1),h=!0);h&&(b=a.join("&"));!d&&c&&(0<b.length&&(b+="&"),b+=e+":"+c);return b}var k=s.ue||{},t=3024E7,n=ue_csm.document||l.document,r=null,d;a:{try{d=l.localStorage;break a}catch(u){}d=void 0}k.count&&k.count("csm.cookieSize",document.cookie.length);k.cookie={get:p,set:m,updateCsmHit:function(b,e,c){try{var a;if(!(a=r)){var f;a:{try{if(d&&d.getItem){f=d.getItem("csm-hit");break a}}catch(k){}f=void 0}a=f||p("csm-hit")||"{}"}a=q(a,b,e);r=a=q(a,"t",+new Date);
+try{d&&d.setItem&&d.setItem("csm-hit",a)}catch(h){}m("csm-hit",a,c)}catch(g){"function"==typeof l.ueLogError&&ueLogError(Error("Cookie manager: "+g.message),{logLevel:"WARN"})}}}})(ue_csm,window);
+
+
+(function(l,e){function c(b){b="";var c=a.isBFT?"b":"s",d=""+a.oid,g=""+a.lid,h=d;d!=g&&20==g.length&&(c+="a",h+="-"+g);a.tabid&&(b=a.tabid+"+");b+=c+"-"+h;b!=f&&100>b.length&&(f=b,a.cookie?a.cookie.updateCsmHit(m,b+("|"+ +new Date)):e.cookie="csm-hit="+b+("|"+ +new Date)+n+"; path=/")}function p(){f=0}function d(b){!0===e[a.pageViz.propHid]?f=0:!1===e[a.pageViz.propHid]&&c({type:"visible"})}var n="; expires="+(new Date(+new Date+6048E5)).toGMTString(),m="tb",f,a=l.ue||{},k=a.pageViz&&a.pageViz.event&&
+a.pageViz.propHid;a.attach&&(a.attach("click",c),a.attach("keyup",c),k||(a.attach("focus",c),a.attach("blur",p)),k&&(a.attach(a.pageViz.event,d,e),d({})));a.aftb=1})(ue_csm,ue_csm.document);
+
+
+ue_csm.ue.stub(ue,"impression");
+
+
+ue.stub(ue,"trigger");
+
+
+if(window.ue&&uet) { uet('bb'); }
+
+}
+</script>
+<script>window.ue && ue.count && ue.count('CSMLibrarySize', 3172)</script>
+<!-- sp:end-feature:csm:head-close -->
+<!-- sp:feature:head-close -->
+<script>
+window.P && P.register('bb');
+if (typeof ues === 'function') {
+  ues('t0', 'portal-bb', new Date());
+  ues('ctb', 'portal-bb', 1);
+}
+</script>
+</head><!-- sp:end-feature:head-close -->
+<!-- sp:feature:start-body -->
+<body class="a-aui_72554-c a-aui_a11y_6_837773-c a-aui_killswitch_csa_logger_372963-t1 a-aui_template_weblab_cache_333406-c a-bw_aui_cxc_alert_measurement_1074111-c a-bw_aui_switch_redesign_measurement_1206055-c"><div id="a-page"><script type="a-state" data-a-state="{&quot;key&quot;:&quot;a-wlab-states&quot;}">{"AUI_TEMPLATE_WEBLAB_CACHE_333406":"C","BW_AUI_CXC_ALERT_MEASUREMENT_1074111":"C","AUI_72554":"C","AUI_A11Y_6_837773":"C","AUI_KILLSWITCH_CSA_LOGGER_372963":"T1","BW_AUI_SWITCH_REDESIGN_MEASUREMENT_1206055":"C"}</script><script>typeof uex === 'function' && uex('ld', 'portal-bb', {wb: 1})</script><!-- sp:end-feature:start-body -->
+<!-- sp:feature:csm:body-open -->
+    <img height="1" width="1" style='display:none;visibility:hidden;' src='//fls-na.amazon.ca/1/batch/1/OP/A2EUQ1WTGCTBG2:133-7199711-5876416:D32ZY1PB3E90Y6D0E1G7$uedata=s:%2Frd%2Fuedata%3Fstaticb%26id%3DD32ZY1PB3E90Y6D0E1G7:0' alt="" onload="window.ue_sbl && window.ue_sbl();"/>
+
+
+<script>
+!function(){function n(n,t){var r=i(n);return t&&(r=r("instance",t)),r}var r=[],c=0,i=function(t){return function(){var n=c++;return r.push([t,[].slice.call(arguments,0),n,{time:Date.now()}]),i(n)}};n._s=r,this.csa=n}();;
+csa('Config', {});
+if (window.csa) {
+    csa("Config", {
+        'Application': 'Retail:Prod:www.amazon.ca',
+        'Events.Namespace': 'csa',
+        'ObfuscatedMarketplaceId': 'A2EUQ1WTGCTBG2',
+        'Events.SushiEndpoint': 'https://unagi.amazon.ca/1/events/com.amazon.csm.csa.prod',
+        'CacheDetection.RequestID': "D32ZY1PB3E90Y6D0E1G7",
+        'CacheDetection.Callback': window.ue && ue.reset,
+        'LCP.elementDedup': 1,
+        'lob': '1'
+    });
+
+    csa("Events")("setEntity", {
+        page: {requestId: "D32ZY1PB3E90Y6D0E1G7", meaningful: "interactive"},
+        session: {id: "133-7199711-5876416"}
+    });
+}
+!function(r){var e,i,o="splice",u=r.csa,f={},c={},a=r.csa._s,s=0,l=0,g=-1,h={},v={},d={},n=Object.keys,p=function(){};function t(n,t){return u(n,t)}function m(n,t){var r=c[n]||{};k(r,t),c[n]=r,l++,S(U,0)}function w(n,t,r){var i=!0;return t=D(t),r&&r.buffered&&(i=(d[n]||[]).every(function(n){return!1!==t(n)})),i?(h[n]||(h[n]=[]),h[n].push(t),function(){!function(n,t){var r=h[n];r&&r[o](r.indexOf(t),1)}(n,t)}):p}function b(n,t){if(t=D(t),n in v)return t(v[n]),p;return w(n,function(n){return t(n),!1})}function y(n,t){if(u("Errors")("logError",n),f.DEBUG)throw t||n}function E(){return Math.abs(4294967295*Math.random()|0).toString(36)}function D(n,t){return function(){try{return n.apply(this,arguments)}catch(n){y(n.message||n,n)}}}function S(n,t){return r.setTimeout(D(n),t)}function U(){for(var n=0;n<a.length;){var t=a[n],r=t[0]in c;if(!r&&!i)return void(s=a.length);r?(a[o](s=n,1),I(t)):n++}g=l}function I(n){var t=c[n[0]],r=n[1],i=r[0];if(!t||!t[i])return y("Undefined function: "+t+"/"+i);e=n[3],c[n[2]]=t[i].apply(t,r.slice(1))||{},e=0}function O(){i=1,U()}function k(t,r){n(r).forEach(function(n){t[n]=r[n]})}b("$beforeunload",O),m("Config",{instance:function(n){k(f,n)}}),u.plugin=D(function(n){n(t)}),t.config=f,t.register=m,t.on=w,t.once=b,t.blank=p,t.emit=function(n,t,r){for(var i=h[n]||[],e=0;e<i.length;)!1===i[e](t)?i[o](e,1):e++;v[n]=t||{},r&&r.buffered&&(d[n]||(d[n]=[]),100<=d[n].length&&d[n].shift(),d[n].push(t||{}))},t.UUID=function(){return[E(),E(),E(),E()].join("-")},t.time=function(n){var t=e?new Date(e.time):new Date;return"ISO"===n?t.toISOString():t.getTime()},t.error=y,t.warn=function(n,t){if(u("Errors")("logWarn",n),f.DEBUG)throw t||n},t.exec=D,t.timeout=S,t.interval=function(n,t){return r.setInterval(D(n),t)},(t.global=r).csa._s.push=function(n){n[0]in c&&(!a.length||i)?(I(n),a.length&&g!==l&&U()):a[o](s++,0,n)},U(),S(function(){S(O,f.SkipMissingPluginsTimeout||5e3)},1)}("undefined"!=typeof window?window:global);csa.plugin(function(o){var f="addEventListener",e="requestAnimationFrame",t=o.exec,r=o.global,u=o.on;o.raf=function(n){if(r[e])return r[e](t(n))},o.on=function(n,e,t,r){if(n&&"function"==typeof n[f]){var i=o.exec(t);return n[f](e,i,r),function(){n.removeEventListener(e,i,r)}}return"string"==typeof n?u(n,e,t,r):o.blank}});csa.plugin(function(o){var t,n,r={},e="localStorage",c="sessionStorage",a="local",i="session",u=o.exec;function s(e,t){var n;try{r[t]=!!(n=o.global[e]),n=n||{}}catch(e){r[t]=!(n={})}return n}function f(){t=t||s(e,a),n=n||s(c,i)}function l(e){return e&&e[i]?n:t}o.store=u(function(e,t,n){f();var o=l(n);return e?t?void(o[e]=t):o[e]:Object.keys(o)}),o.storageSupport=u(function(){return f(),r}),o.deleteStored=u(function(e,t){f();var n=l(t);if("function"==typeof e)for(var o in n)n.hasOwnProperty(o)&&e(o,n[o])&&delete n[o];else delete n[e]})});csa.plugin(function(n){n.types={ovl:function(n){var r=[];if(n)for(var i in n)n.hasOwnProperty(i)&&r.push(n[i]);return r}}});csa.plugin(function(a){var e=a.config,n="Errors",c="fcsmln",s=e["KillSwitch."+n];function r(n){return function(e){a("Metrics",{producerId:"csa",dimensions:{message:e}})("recordMetric",n,1)}}function t(r){var t,o,l=a("Events",{producerId:r.producerId,lob:e.lob||"0"}),i=["name","type","csm","adb"],u={url:"pageURL",file:"f",line:"l",column:"c"};this.log=function(e){if(!s&&!function(e){if(!e)return!0;for(var n in e)return!1;return!0}(e)){var n=r.logOptions||{ent:{page:["pageType","subPageType","requestId"]}};l("log",function(n){return t=a.UUID(),o={messageId:t,schemaId:r.schemaId||"<ns>.Error.6",errorMessage:n.m||null,attribution:n.attribution||null,logLevel:"FATAL",url:null,file:null,line:null,column:null,stack:n.s||[],context:n.cinfo||{},metadata:{}},n.logLevel&&(o.logLevel=""+n.logLevel),i.forEach(function(e){n[e]&&(o.metadata[e]=n[e])}),c in n&&(o.metadata[c]=n[c]+""),"INFO"===n.logLevel||Object.keys(u).forEach(function(e){"number"!=typeof n[u[e]]&&"string"!=typeof n[u[e]]||(o[e]=""+n[u[e]])}),o}(e),n)}}}a.register(n,{instance:function(e){return new t(e||{})},logError:r("jsError"),logWarn:r("jsWarn")})});csa.plugin(function(o){var r,e,n,t,a,i="function",u="willDisappear",f="$app.",p="$document.",c="focus",s="blur",d="active",l="resign",$=o.global,b=o.exec,m=o.config["Transport.AnonymizeRequests"]||!1,g=o("Events"),h=$.location,v=$.document||{},y=$.P||{},P=(($.performance||{}).navigation||{}).type,w=o.on,k=o.emit,E=v.hidden,T={};h&&v&&(w($,"beforeunload",D),w($,"pagehide",D),w(v,"visibilitychange",R(p,function(){return v.visibilityState||"unknown"})),w(v,c,R(p+c)),w(v,s,R(p+s)),y.when&&y.when("mash").execute(function(e){e&&(w(e,"appPause",R(f+"pause")),w(e,"appResume",R(f+"resume")),R(f+"deviceready")(),$.cordova&&$.cordova.platformId&&R(f+cordova.platformId)(),w(v,d,R(f+d)),w(v,l,R(f+l)))}),e=$.app||{},n=b(function(){k(f+"willDisappear"),D()}),a=typeof(t=e[u])==i,e[u]=b(function(){n(),a&&t()}),$.app||($.app=e),"complete"===v.readyState?A():w($,"load",A),E?S():x(),o.on("$app.blur",S),o.on("$app.focus",x),o.on("$document.blur",S),o.on("$document.focus",x),o.on("$document.hidden",S),o.on("$document.visible",x),o.register("SPA",{newPage:I}),I({transitionType:{0:"hard",1:"refresh",2:"back-button"}[P]||"unknown"}));function I(n,e){var t=!!r,a=(e=e||{}).keepPageAttributes;t&&(k("$beforePageTransition"),k("$pageTransition")),t&&!a&&g("removeEntity","page"),r=o.UUID(),a?T.id=r:T={schemaId:"<ns>.PageEntity.2",id:r,url:m?h.href.split("?")[0]:h.href,server:h.hostname,path:h.pathname,referrer:m?v.referrer.split("?")[0]:v.referrer,title:v.title},Object.keys(n||{}).forEach(function(e){T[e]=n[e]}),g("setEntity",{page:T}),k("$pageChange",T,{buffered:1}),t&&k("$afterPageTransition")}function A(){k("$load"),k("$ready"),k("$afterload")}function D(){k("$ready"),k("$beforeunload"),k("$unload"),k("$afterunload")}function S(){E||(k("$visible",!1,{buffered:1}),E=!0)}function x(){E&&(k("$visible",!0,{buffered:1}),E=!1)}function R(n,t){return b(function(){var e=typeof t==i?n+t():n;k(e)})}});csa.plugin(function(c){var e="Events",n="UNKNOWN",s="id",a="all",i="messageId",o="timestamp",u="producerId",r="application",f="obfuscatedMarketplaceId",d="entities",l="schemaId",p="version",v="attributes",g="<ns>",b="lob",t="session",h=c.config,m=(c.global.location||{}).host,I=h[e+".Namespace"]||"csa_other",y=h.Application||"Other"+(m?":"+m:""),O=h["Transport.AnonymizeRequests"]||!1,E=c("Transport"),U={},A=function(e,t){Object.keys(e).forEach(t)};function N(n,i,o){A(i,function(e){var t=o===a||(o||{})[e];e in n||(n[e]={version:1,id:i[e][s]||c.UUID()}),S(n[e],i[e],t)})}function S(t,n,i){A(n,function(e){!function(e,t,n){return"string"!=typeof t&&e!==p?c.error("Attribute is not of type string: "+e):!0===n||1===n||(e===s||!!~(n||[]).indexOf(e))}(e,n[e],i)||(t[e]=n[e])})}function k(o,e,r){A(e,function(e){var t=o[e];if(t[l]){var n={},i={};n[s]=t[s],n[u]=t[u]||r[u],n[l]=t[l],n[p]=t[p]++,n[v]=i,w(n,r),S(i,t,1),D(i),E("log",n)}})}function w(e,t){e[o]=function(e){return"number"==typeof e&&(e=new Date(e).toISOString()),e||c.time("ISO")}(e[o]),e[i]=e[i]||c.UUID(),e[r]=y,e[f]=h.ObfuscatedMarketplaceId||n,e[l]=e[l].replace(g,I),t&&t[b]&&(e[b]=t[b])}function D(e){delete e[p],delete e[l],delete e[u]}function T(o){var r={};this.log=function(e,t){var n={},i=(t||{}).ent;return e?"string"!=typeof e[l]?c.error("A valid schema id is required for the event"):(w(e,o),N(n,U,i),N(n,r,i),N(n,e[d]||{},i),A(n,function(e){D(n[e])}),e[u]=o[u],e[d]=n,t&&t[b]&&(e[b]=t[b]),void E("log",e,t)):c.error("The event cannot be undefined")},this.setEntity=function(e){O&&delete e[t],N(r,e,a),k(r,e,o)}}h["KillSwitch."+e]||c.register(e,{setEntity:function(e){O&&delete e[t],c.emit("$entities.set",e,{buffered:1}),N(U,e,a),k(U,e,{producerId:"csa",lob:h[b]||"0"})},removeEntity:function(e){delete U[e]},instance:function(e){return new T(e)}})});csa.plugin(function(s){var c,g="Transport",l="post",f="preflight",r="csa.cajun.",i="store",a="deleteStored",u="sendBeacon",t="__merge",e="messageId",n=".FlushInterval",o=0,d=s.config[g+".BufferSize"]||2e3,h=s.config[g+".RetryDelay"]||1500,p=s.config[g+".AnonymizeRequests"]||!1,v={},y=0,m=[],E=s.global,R=E.document,b=s.timeout,k=E.Object.keys,w=s.config[g+n]||5e3,I=w,O=s.config[g+n+".BackoffFactor"]||1,S=s.config[g+n+".BackoffLimit"]||3e4,B=0;function T(n){if(864e5<s.time()-+new Date(n.timestamp))return s.warn("Event is too old: "+n);y<d&&(n[e]in v||(v[n[e]]=n,y++),"function"==typeof n[t]&&n[t](v[n[e]]),!B&&o&&(B=b(q,function(){var n=I;return I=Math.min(n*O,S),n}())))}function q(){m.forEach(function(e){var o=[];k(v).forEach(function(n){var t=v[n];e.accepts(t)&&o.push(t)}),o.length&&(e.chunks?e.chunks(o).forEach(function(n){D(e,n)}):D(e,o))}),v={},B=0}function D(t,e){function o(){s[a](r+n)}var n=s.UUID();s[i](r+n,JSON.stringify(e)),[function(n,t,e){var o=E.navigator||{},r=E.cordova||{};if(p)return 0;if(!o[u]||!n[l])return 0;n[f]&&r&&"ios"===r.platformId&&!c&&((new Image).src=n[f]().url,c=1);var i=n[l](t);if(!i.type&&o[u](i.url,i.body))return e(),1},function(n,t,e){if(!n[l])return 0;var o=n[l](t),r=o.url,i=o.body,c=o.type,f=new XMLHttpRequest,a=0;function u(n,t,e){f.open("POST",n),f.withCredentials=!p,e&&f.setRequestHeader("Content-Type",e),f.send(t)}return f.onload=function(){f.status<299?e():s.config[g+".XHRRetries"]&&a<3&&b(function(){u(r,i,c)},++a*h)},u(r,i,c),1}].some(function(n){try{return n(t,e,o)}catch(n){}})}k&&(s.once("$afterload",function(){o=1,function(e){(s[i]()||[]).forEach(function(n){if(!n.indexOf(r))try{var t=s[i](n);s[a](n),JSON.parse(t).forEach(e)}catch(n){s.error(n)}})}(T),s.on(R,"visibilitychange",q,!1),q()}),s.once("$afterunload",function(){o=1,q()}),s.on("$afterPageTransition",function(){y=0,I=w}),s.register(g,{log:T,register:function(n){m.push(n)}}))});csa.plugin(function(n){var r=n.config["Events.SushiEndpoint"];n("Transport")("register",{accepts:function(n){return n.schemaId},post:function(n){var t=n.map(function(n){return{data:n}});return{url:r,body:JSON.stringify({events:t})}},preflight:function(){var n,t=/\/\/(.*?)\//.exec(r);return t&&t[1]&&(n="https://"+t[1]+"/ping"),{url:n}},chunks:function(n){for(var t=[];500<n.length;)t.push(n.splice(0,500));return t.push(n),t}})});csa.plugin(function(n){var t,a,o,r,e=n.config,i="PageViews",d=e[i+".ImpressionMinimumTime"]||1e3,s="hidden",c="innerHeight",l="innerWidth",g="renderedTo",f=g+"Viewed",m=g+"Meaningful",u=g+"Impressed",p=1,h=2,v=3,w=4,P=5,y="loaded",I=7,b=8,T=n.global,S=n.on,E=n("Events",{producerId:"csa",lob:e.lob||"0"}),K=T.document,V={},$={},M=P,R=e["KillSwitch."+i],H=e["KillSwitch.PageRender"],W=e["KillSwitch.PageImpressed"];function j(e){if(!V[I]){if(V[e]=n.time(),e!==v&&e!==y||(t=t||V[e]),t&&M===w){if(a=a||V[e],!R)(i={})[m]=t-o,i[f]=a-o,k("PageView.5",i);r=r||n.timeout(x,d)}var i;if(e!==P&&e!==p&&e!==h||(clearTimeout(r),r=0),e!==p&&e!==h||H||k("PageRender.4",{transitionType:e===p?"hard":"soft"}),e===I&&!W)(i={})[m]=t-o,i[f]=a-o,i[u]=V[e]-o,k("PageImpressed.3",i)}}function k(e,i){$[e]||(i.schemaId="<ns>."+e,E("log",i,{ent:"all"}),$[e]=1)}function q(){0===T[c]&&0===T[l]?(M=b,n("Events")("setEntity",{page:{viewport:"hidden-iframe"}})):M=K[s]?P:w,j(M)}function x(){j(I),r=0}function z(){var e=o?h:p;V={},$={},a=t=0,o=n.time(),j(e),q()}function A(){var e=K.readyState;"interactive"===e&&j(v),"complete"===e&&j(y)}K&&void 0!==K[s]?(z(),S(K,"visibilitychange",q,!1),S(K,"readystatechange",A,!1),S("$afterPageTransition",z),S("$timing:loaded",A),n.once("$load",A)):n.warn("Page visibility not supported")});csa.plugin(function(c){var s=c.config["Interactions.ParentChainLength"]||35,e="click",r="touches",f="timeStamp",o="length",u="pageX",g="pageY",p="pageXOffset",h="pageYOffset",m=250,v=5,d=200,l=.5,t={capture:!0,passive:!0},X=c.global,Y=c.emit,n=c.on,x=X.Math.abs,a=(X.document||{}).documentElement||{},y={x:0,y:0,t:0,sX:0,sY:0},N={x:0,y:0,t:0,sX:0,sY:0};function b(t){if(t.id)return"//*[@id='"+t.id+"']";var e=function(t){var e,n=1;for(e=t.previousSibling;e;e=e.previousSibling)e.nodeName===t.nodeName&&(n+=1);return n}(t),n=t.nodeName;return 1!==e&&(n+="["+e+"]"),t.parentNode&&(n=b(t.parentNode)+"/"+n),n}function I(t,e,n){var a=c("Content",{target:n}),i={schemaId:"<ns>.ContentInteraction.2",interaction:t,interactionData:e,messageId:c.UUID()};if(n){var r=b(n);r&&(i.attribution=r);var o=function(t){for(var e=t,n=e.tagName,a=!1,i=t?t.href:null,r=0;r<s;r++){if(!e||!e.parentElement){a=!0;break}n=(e=e.parentElement).tagName+"/"+n,i=i||e.href}return a||(n=".../"+n),{pc:n,hr:i}}(n);o.pc&&(i.interactionData.parentChain=o.pc),o.hr&&(i.interactionData.href=o.hr)}a("log",i),Y("$content.interaction",{e:i,w:a})}function i(t){I(e,{interactionX:""+t.pageX,interactionY:""+t.pageY},t.target)}function C(t){if(t&&t[r]&&1===t[r][o]){var e=t[r][0];N=y={e:t.target,x:e[u],y:e[g],t:t[f],sX:X[p],sY:X[h]}}}function D(t){if(t&&t[r]&&1===t[r][o]&&y&&N){var e=t[r][0],n=t[f],a=n-N.t,i={e:t.target,x:e[u],y:e[g],t:n,sX:X[p],sY:X[h]};N=i,d<=a&&(y=i)}}function E(t){if(t){var e=x(y.x-N.x),n=x(y.y-N.y),a=x(y.sX-N.sX),i=x(y.sY-N.sY),r=t[f]-y.t;if(m<1e3*e/r&&v<e||m<1e3*n/r&&v<n){var o=n<e;o&&a&&e*l<=a||!o&&i&&n*l<=i||I((o?"horizontal":"vertical")+"-swipe",{interactionX:""+y.x,interactionY:""+y.y,endX:""+N.x,endY:""+N.y},y.e)}}}n(a,e,i,t),n(a,"touchstart",C,t),n(a,"touchmove",D,t),n(a,"touchend",E,t)});csa.plugin(function(s){var a,o,t,c,e,n="MutationObserver",l="observe",i="disconnect",f="_csa_flt",b="_csa_llt",d="_csa_mr",p="_csa_mi",v="lastChild",m="length",h={childList:!0,subtree:!0},_=10,g=25,r=1e3,y=4,u=s.global,k=u.document,w=k.body||k.documentElement,I=Date.now,L=[],O=[],B=[],M=0,x=0,C=0,D=1,E=[],F=[],S=0,V=s.blank;I&&u[n]&&(M=0,o=new u[n]($),(t=new u[n](Y))[l](w,{attributes:!0,subtree:!0,attributeFilter:["src"],attributeOldValue:!0}),V=s.on(u,"scroll",j,{passive:!0}),s.once("$ready",A),D&&(z(),e=s.interval(q,r)),s.register("SpeedIndexBuffers",{getBuffers:function(e){e&&(A(),j(),e(M,E,L,O,B),o&&o[i](),t&&t[i](),V())},registerListener:function(e){a=e},replayModuleIsLive:function(){s.timeout(A,0)}}));function Y(e){L.push({t:I(),m:e})}function $(e){O.push({t:I(),m:e}),C=1,a&&a()}function j(){C&&(B.push({t:I(),y:x}),x=u.pageYOffset,C=0)}function q(){var e=I();(!c||r<e-c)&&z()}function z(){for(var e=w,t=I(),n=[],i=[],r=0,u=0;e;)e[f]?++r:(e[f]=t,n.push(e),u=1),i[m]<y&&i.push(e),e[p]=S,e[b]=t,e=e[v];u&&(r<F[m]&&function(e){for(var t=e,n=F[m];t<n;t++){var i=F[t];if(i){if(i[d])break;if(i[p]<S){i[d]=1,o[l](i,h);break}}}}(r),F=i,E.push({t:t,m:n}),++S,C=u,a&&a()),D&&s.timeout(z,u?_:g),c=t}function A(){D&&(D=0,e&&u.clearInterval(e),e=null,z(),o[l](w,h))}});
+csa.plugin(function(b){var a=b.global,c=a.uet,e=a.uex,f=a.ue,a=a.Object,g=0,h={largestContentfulPaint:"lcp",visuallyLoaded50:"vl50",visuallyLoaded90:"vl90",visuallyLoaded100:"vl100"};b&&c&&e&&a.keys&&f&&(b.once("$ditched.beforemitigation",function(){g=1}),a.keys(h).forEach(function(a){b.on("$timing:"+a,function(b){var d=h[a];if(f.isl||g){var k="csa:"+d;c(d,k,void 0,b);e("at",k)}else c(d,void 0,void 0,b)})}))});
+
+
+window.rx = { 'rid':'D32ZY1PB3E90Y6D0E1G7', 'sid':'133-7199711-5876416', 'c':{  'rxp':'/rd/uedata' }};
+</script>
+<script>window.ue && ue.count && ue.count('CSMLibrarySize', 16163)</script>
+<!-- sp:end-feature:csm:body-open -->
+<!-- sp:feature:nav-inline-js -->
+<!-- NAVYAAN JS -->
+
+<script type="text/javascript">!function(n){function e(n,e){return{m:n,a:function(n){return[].slice.call(n)}(e)}}document.createElement("header");var r=function(n){function u(n,r,u){n[u]=function(){a._replay.push(r.concat(e(u,arguments)))}}var a={};return a._sourceName=n,a._replay=[],a.getNow=function(n,e){return e},a.when=function(){var n=[e("when",arguments)],r={};return u(r,n,"run"),u(r,n,"declare"),u(r,n,"publish"),u(r,n,"build"),r.depends=n,r.iff=function(){var r=n.concat([e("iff",arguments)]),a={};return u(a,r,"run"),u(a,r,"declare"),u(a,r,"publish"),u(a,r,"build"),a},r},u(a,[],"declare"),u(a,[],"build"),u(a,[],"publish"),u(a,[],"importEvent"),r._shims.push(a),a};r._shims=[],n.$Nav||(n.$Nav=r("rcx-nav")),n.$Nav.make||(n.$Nav.make=r)}(window)</script><script type="text/javascript">
+$Nav.importEvent('navbarJS-beaconbelt');
+$Nav.declare('img.sprite', {
+  'png32': 'https://m.media-amazon.com/images/G/15/gno/sprites/nav-sprite-global-1x-reorg-privacy._CB546817341_.png',
+  'png32-2x': 'https://m.media-amazon.com/images/G/15/gno/sprites/nav-sprite-global-2x-reorg-privacy._CB546817341_.png'
+});
+$Nav.declare('img.timeline', {
+  'timeline-icon-2x': 'https://m.media-amazon.com/images/G/15/gno/sprites/timeline_sprite_2x._CB443581337_.png'
+});
+window._navbarSpriteUrl = 'https://m.media-amazon.com/images/G/15/gno/sprites/nav-sprite-global-1x-reorg-privacy._CB546817341_.png';
+$Nav.declare('img.pixel', 'https://m.media-amazon.com/images/G/15/x-locale/common/transparent-pixel._CB485935025_.gif');
+</script>
+
+<img src="https://m.media-amazon.com/images/G/15/gno/sprites/nav-sprite-global-1x-reorg-privacy._CB546817341_.png" style="display:none" alt=""/>
+<script type="text/javascript">var nav_t_after_preload_sprite = + new Date();</script>
+<script>
+(window.AmazonUIPageJS ? AmazonUIPageJS : P).when('navCF').execute(function() {
+  (window.AmazonUIPageJS ? AmazonUIPageJS : P).load.js('https://images-na.ssl-images-amazon.com/images/I/514I0Eu-jKL._RC|71XivtDwdaL.js,01kc2Ns67ML.js,01VfhmbHmKL.js,71ul8BNQEtL.js,01cZ21lATAL.js,01bAfFgS7JL.js,01A2AtmCtlL.js,41jBieyCvYL.js,01wXnKULArL.js,01+pnQJuQ0L.js,21UXsP5YTYL.js,41OnVkO2wEL.js,414stvo6DvL.js,31XO9BO1OrL.js,11lw6J7z8iL.js,31+UifI0MIL.js,01VYGE8lGhL.js_.js?AUIClients/NavDesktopUberAsset#desktop.language-en.ca.1173925-T1.1089717-T1.948355-T2.1195549-T1.1222395-T1');
+});
+</script>
+<!-- sp:end-feature:nav-inline-js -->
+<!-- sp:feature:nav-skeleton -->
+<!-- sp:end-feature:nav-skeleton -->
+<!-- sp:feature:navbar -->
+
+<!--Pilu -->
+
+
+  <!-- NAVYAAN -->
+
+
+
+
+
+
+
+
+
+
+
+<!-- navmet initial definition -->
+
+
+
+<script type='text/javascript'>
+    if(window.navmet===undefined) {
+      window.navmet=[];
+      if (window.performance && window.performance.timing && window.ue_t0) {
+        var t = window.performance.timing;
+        var now = + new Date();
+        window.navmet.basic = {
+          'networkLatency': (t.responseStart - t.fetchStart),
+          'navFirstPaint': (now - t.responseStart),
+          'NavStart': (now - window.ue_t0)
+        };
+        window.navmet.push({key:"NavFirstPaintStart",end:+new Date(),begin:window.ue_t0});
+      }
+    }
+    if (window.ue_t0) {
+      window.navmet.push({key:"NavMainStart",end:+new Date(),begin:window.ue_t0});
+    }
+</script>
+
+
+
+
+<script type='text/javascript'>window.navmet.tmp=+new Date();</script>
+  <script type='text/javascript'>
+    // Nav start should be logged at this place only if request is NOT progressively loaded.
+    // For progressive loading case this metric is logged as part of skeleton.
+    // Presence of skeleton signals that request is progressively loaded.
+    if(!document.getElementById("navbar-skeleton")) {
+      window.uet && uet('ns');
+    }
+    window._navbar = (function (o) {
+      o.componentLoaded = o.loading = function(){};
+      o.browsepromos = {};
+      o.issPromos = [];
+      return o;
+    }(window._navbar || {}));
+    window._navbar.declareOnLoad = function () { window.$Nav && $Nav.declare('page.load'); };
+    if (window.addEventListener) {
+      window.addEventListener("load", window._navbar.declareOnLoad, false);
+    } else if (window.attachEvent) {
+      window.attachEvent("onload", window._navbar.declareOnLoad);
+    } else if (window.$Nav) {
+      $Nav.when('page.domReady').run("OnloadFallbackSetup", function () {
+        window._navbar.declareOnLoad();
+      });
+    }
+    window.$Nav && $Nav.declare('logEvent.enabled',
+      'false');
+
+    window.$Nav && $Nav.declare('config.lightningDeals', {"activeItems":[],"marketplaceID":"A2EUQ1WTGCTBG2","customerID":"A3QJNV48OOU9F8"});
+  </script>
+
+    <style mark="aboveNavInjectionCSS" type="text/css">
+      div#navSwmHoliday.nav-focus {border: none;margin: 0;}#navbar.nav-pinned-pinata #nav-tools .nav-line-3 { height: 16px;line-height:16px;}div#navSwmHoliday.nav-focus {border-bottom: none;margin-top: 0;} #nav-flyout-ewc .nav-flyout-buffer-left { display: none; } #nav-flyout-ewc .nav-flyout-buffer-right { display: none; } 
+    </style>
+    <script mark="aboveNavInjectionJS" type="text/javascript">
+      try {
+        window.$Nav && $Nav.when('$').run('defineIsArray', function(jQuery) { if(jQuery.isArray===undefined) { jQuery.isArray=function(param) { if(param.length===undefined) { return false; } return true; }; } }); window.$Nav && window.$Nav.when("$","subnav.initFlyouts","constants","nav.inline").build("subnav.builder",function(a,t,e){var n=a("#navbar");return function(s){var r=a("#nav-subnav");if(0===r.length&&(r=a("<div id='nav-subnav'></div>").appendTo("#navbar")),r.html(""),n.removeClass("nav-subnav"),s.categoryKey&&s.digest){r.attr("data-category",s.categoryKey).attr("data-digest",s.digest).attr("class",s.category.data.categoryStyle),s.style?r.attr("style",s.style):r.attr("style")&&r.removeAttr("style");var i=function(t){if(t&&t.href){var n="nav-a",s=t.text,i=t.dataKey;if(!s&&!t.image){if(!i||0!==i.indexOf(e.ADVANCED_PREFIX))return;s="",n+=" nav-aText"}var d=t.image?"<img src='"+t.image+"'class='nav-categ-image' ></a>":s,l=a("<a href='"+t.href+"' class='"+n+"'></a>"),v=a("<span class='nav-a-content'>"+d+"</span>");if("image"===t.type&&(v.html(""),l.addClass("nav-hasImage"),t.rightText=""),t.bold&&!t.image&&l.addClass("nav-b"),t.floatRight&&l.addClass("nav-right"),t.flyoutFullWidth&&"0"!==t.flyoutFullWidth&&l.attr("data-nav-flyout-full-width","1"),t.src){var g=["nav-image"];t["absolute-right"]&&g.push("nav-image-abs-right"),t["absolute-right"]&&g.push("nav-image-abs-right"),a("<img src='"+t.src+"' class='"+g.join(" ")+"' alt='"+(t.alt||"")+"' />").appendTo(v)}t.rightText&&v.append(t.rightText),v.appendTo(l),i&&(a("<span class='nav-arrow'></span>").appendTo(l),l.attr("data-nav-key",i).addClass("nav-hasArrow")),l.appendTo(r),r.append(document.createTextNode(" "))}};if(s.category&&s.category.data&&(s.category.data.bold=!0,i(s.category.data)),s.subnav&&"linkSequence"===s.subnav.type)for(var d=0;d<s.subnav.data.length;d++)i(s.subnav.data[d]);n.addClass("nav-subnav"),t()}}}); window.$Nav && $Nav.when('$','$F','config','logEvent','panels','phoneHome','dataPanel','flyouts.renderPromo','flyouts.sloppyTrigger','flyouts.accessibility','util.mouseOut','util.onKey','debug.param').build('flyouts.buildSubPanels',function($,$F,config,logEvent,panels,phoneHome,dataPanel,renderPromo,createSloppyTrigger,a11yHandler,mouseOutUtility,onKey,debugParam){var flyoutDebug=debugParam('navFlyoutClick');return function(flyout,event){var linkKeys=[];$('.nav-item',flyout.elem()).each(function(){var $item=$(this);linkKeys.push({link:$item,panelKey:$item.attr('data-nav-panelkey')});});if(linkKeys.length===0){return;} var visible=false;var $parent=$('<div class=\'nav-subcats\'></div>').appendTo(flyout.elem());var panelGroup=flyout.getName()+'SubCats';var hideTimeout=null;var sloppyTrigger=createSloppyTrigger($parent);var showParent=function(){if(hideTimeout){clearTimeout(hideTimeout);hideTimeout=null;} if(visible){return;} var height=$('#nav-flyout-shopAll').height();$parent.css({'height': height});$parent.animate({width:'show'},{duration:200,complete:function(){$parent.css({overflow:'visible'});}});visible=true;};var hideParentNow=function(){$parent.stop().css({overflow:'hidden',display:'none',width:'auto',height:'auto'});panels.hideAll({group:panelGroup});visible=false;if(hideTimeout){clearTimeout(hideTimeout);hideTimeout=null;}};var hideParent=function(){if(!visible){return;} if(hideTimeout){clearTimeout(hideTimeout);hideTimeout=null;} hideTimeout=setTimeout(hideParentNow,10);};flyout.onHide(function(){sloppyTrigger.disable();hideParentNow();this.elem().hide();});var addPanel=function($link,panelKey){var panel=dataPanel({className:'nav-subcat',dataKey:panelKey,groups:[panelGroup],spinner:false,visible:false});if(!flyoutDebug){var mouseout=mouseOutUtility();mouseout.add(flyout.elem());mouseout.action(function(){panel.hide();});mouseout.enable();} var a11y=a11yHandler({link:$link,onEscape:function(){panel.hide();$link.focus();}});var logPanelInteraction=function(promoID,wlTriggers){var logNow=$F.once().on(function(){var panelEvent=$.extend({},event,{id:promoID});if(config.browsePromos&&!!config.browsePromos[promoID]){panelEvent.bp=1;} logEvent(panelEvent);phoneHome.trigger(wlTriggers);});if(panel.isVisible()&&panel.hasInteracted()){logNow();}else{panel.onInteract(logNow);}};panel.onData(function(data){renderPromo(data.promoID,panel.elem());logPanelInteraction(data.promoID,data.wlTriggers);});panel.onShow(function(){var columnCount=$('.nav-column',panel.elem()).length;panel.elem().addClass('nav-colcount-'+columnCount);showParent();var $subCatLinks=$('.nav-subcat-links > a',panel.elem());var length=$subCatLinks.length;if(length>0){var firstElementLeftPos=$subCatLinks.eq(0).offset().left;for(var i=1;i<length;i++){if(firstElementLeftPos===$subCatLinks.eq(i).offset().left){$subCatLinks.eq(i).addClass('nav_linestart');}} if($('span.nav-title.nav-item',panel.elem()).length===0){var catTitle=$.trim($link.html());catTitle=catTitle.replace(/ref=sa_menu_top/g,'ref=sa_menu');var $subPanelTitle=$('<span class=\'nav-title nav-item\'>'+ catTitle+'</span>');panel.elem().prepend($subPanelTitle);}} $link.addClass('nav-active');});panel.onHide(function(){$link.removeClass('nav-active');hideParent();a11y.disable();sloppyTrigger.disable();});panel.onShow(function(){a11y.elems($('a, area',panel.elem()));});sloppyTrigger.register($link,panel);if(flyoutDebug){$link.click(function(){if(panel.isVisible()){panel.hide();}else{panel.show();}});} var panelKeyHandler=onKey($link,function(){if(this.isEnter()||this.isSpace()){panel.show();}},'keydown',false);$link.focus(function(){panelKeyHandler.bind();}).blur(function(){panelKeyHandler.unbind();});panel.elem().appendTo($parent);};var hideParentAndResetTrigger=function(){hideParent();sloppyTrigger.disable();};for(var i=0;i<linkKeys.length;i++){var item=linkKeys[i];if(item.panelKey){addPanel(item.link,item.panelKey);}else{item.link.mouseover(hideParentAndResetTrigger);}}};});
+      } catch ( err ) {
+        if ( window.$Nav ) {
+          window.$Nav.when('metrics', 'logUeError').run(function(metrics, log) {
+            metrics.increment('NavJS:AboveNavInjection:error');
+            log(err.toString(), {
+              'attribution': 'rcx-nav',
+              'logLevel': 'FATAL'
+            });
+          });
+        }
+      }
+    </script>
+
+  <noscript>
+    <style type="text/css"><!--
+      #navbar #nav-shop .nav-a:hover {
+        color: #ff9900;
+        text-decoration: underline;
+      }
+      #navbar #nav-search .nav-search-facade,
+      #navbar #nav-tools .nav-icon,
+      #navbar #nav-shop .nav-icon,
+      #navbar #nav-subnav .nav-hasArrow .nav-arrow {
+        display: none;
+      }
+      #navbar #nav-search .nav-search-submit,
+      #navbar #nav-search .nav-search-scope {
+        display: block;
+      }
+      #nav-search .nav-search-scope {
+        padding: 0 5px;
+      }
+      #navbar #nav-search .nav-search-dropdown {
+        position: relative;
+        top: 5px;
+        height: 23px;
+        font-size: 14px;
+        opacity: 1;
+        filter: alpha(opacity = 100);
+      }
+    --></style>
+ </noscript>
+<script type='text/javascript'>window.navmet.push({key:'PreNav',end:+new Date(),begin:window.navmet.tmp});</script>
+
+<a id='nav-top'></a>
+
+
+
+
+
+  
+<nav
+  id="shortcut-menu"
+  class="nav-assistant"
+  aria-label="Shortcuts menu"
+  tabindex="-1"
+  role="navigation"
+  
+>
+  <h2 id="nav-assistant-links-heading" class="nav-assistant-heading nav-assistant-headers-font">Skip to</h2>
+  <ul aria-labelledby="nav-assistant-links-heading" class="nav-assistant-links-container">
+    <li class="nav-assistant-list-item">
+      <a
+        href="#skippedLink"
+        id="nav-assist-skip-to-main-content"
+        aria-label="main content"
+        tabindex="0"
+        data-target="#skippedLink"
+        data-behavior="navigate"
+        
+        
+        data-nav-assist-menu-item-index="0"
+        class="nav-assistant-link nav-assistant-menu-item nav-assistant-link-item a-color-base a-color-link "
+      >
+        Main content
+        </a>
+    </li>
+  </ul>
+  <hr class="nav-assistant-separator" aria-hidden="true" />
+  <h2 id="shortcuts-heading" class="nav-assistant-heading nav-assistant-headers-font font-color">
+      Keyboard shortcuts
+  </h2>
+  <ul class="keyboard-shortcuts-list-container" aria-labelledby="shortcuts-heading">
+    <li class="nav-assistant-list-item">
+      <a
+        id="nav-assist-search"
+        role="link"
+        tabindex="-1"
+        class="nav-assistant-menu-item nav-assistant-link-item nav-assistant-keyboard-shortcut-item keyboard-shortcut-menu-container a-color-base a-color-link "
+        data-nav-assist-menu-item-index="1"
+        data-behavior="navigate"
+        
+        data-actuators="[{&quot;eventCode&quot;:&quot;Slash&quot;,&quot;eventKey&quot;:&quot;÷&quot;,&quot;isShiftRequired&quot;:false},{&quot;eventCode&quot;:&quot;Digit7&quot;,&quot;eventKey&quot;:&quot;\\&quot;,&quot;isShiftRequired&quot;:true},{&quot;eventCode&quot;:&quot;Period&quot;,&quot;eventKey&quot;:&quot;\\&quot;,&quot;isShiftRequired&quot;:true},{&quot;eventCode&quot;:&quot;Slash&quot;,&quot;eventKey&quot;:&quot;/&quot;,&quot;isShiftRequired&quot;:false},{&quot;eventCode&quot;:&quot;Digit7&quot;,&quot;eventKey&quot;:&quot;/&quot;,&quot;isShiftRequired&quot;:true},{&quot;eventCode&quot;:&quot;Period&quot;,&quot;eventKey&quot;:&quot;/&quot;,&quot;isShiftRequired&quot;:true},{&quot;eventKey&quot;:&quot;/&quot;,&quot;isShiftRequired&quot;:false}]"
+        data-target="#twotabsearchtextbox"
+        aria-label="Search, Option, forward slash"
+      >
+      <div class="keyboard-shortcut-container" aria-hidden="true">
+        <span class="shortcut-name nav-assistant-card-font">Search</span>
+        <div class="shortcut-keys-container" dir="ltr">
+            <span class="shortcut-key nav-assistant-card-font font-color">Opt</span>
+            <span class="plus-sign-color">+</span>
+            <span class="shortcut-key nav-assistant-card-font font-color">/</span>
+            
+        </div>
+      </div>
+      </a>
+    </li>
+    <li class="nav-assistant-list-item">
+      <a
+        id="nav-assist-cart"
+        role="link"
+        tabindex="-1"
+        class="nav-assistant-menu-item nav-assistant-link-item nav-assistant-keyboard-shortcut-item keyboard-shortcut-menu-container a-color-base a-color-link "
+        data-nav-assist-menu-item-index="2"
+        data-behavior="navigate"
+        
+        data-actuators="[{&quot;eventKey&quot;:&quot;Ç&quot;,&quot;eventCode&quot;:&quot;KeyC&quot;,&quot;isShiftRequired&quot;:true},{&quot;eventKey&quot;:&quot;¢&quot;,&quot;eventCode&quot;:&quot;KeyC&quot;,&quot;isShiftRequired&quot;:true},{&quot;eventKey&quot;:&quot;C&quot;,&quot;isShiftRequired&quot;:true}]"
+        data-target="/gp/cart/view.html/?ref_&#x3D;nav_assist"
+        aria-label="Cart, shift, Option, c"
+      >
+      <div class="keyboard-shortcut-container" aria-hidden="true">
+        <span class="shortcut-name nav-assistant-card-font">Cart</span>
+        <div class="shortcut-keys-container" dir="ltr">
+            <span class="shortcut-key nav-assistant-card-font font-color">Shift</span>
+            <span class="plus-sign-color">+</span>
+            <span class="shortcut-key nav-assistant-card-font font-color">Opt</span>
+            <span class="plus-sign-color">+</span>
+            <span class="shortcut-key nav-assistant-card-font font-color">C</span>
+            
+        </div>
+      </div>
+      </a>
+    </li>
+    <li class="nav-assistant-list-item">
+      <a
+        id="nav-assist-home"
+        role="link"
+        tabindex="-1"
+        class="nav-assistant-menu-item nav-assistant-link-item nav-assistant-keyboard-shortcut-item keyboard-shortcut-menu-container a-color-base a-color-link "
+        data-nav-assist-menu-item-index="3"
+        data-behavior="navigate"
+        
+        data-actuators="[{&quot;eventKey&quot;:&quot;Ó&quot;,&quot;eventCode&quot;:&quot;KeyH&quot;,&quot;isShiftRequired&quot;:true},{&quot;eventKey&quot;:&quot;Î&quot;,&quot;eventCode&quot;:&quot;KeyH&quot;,&quot;isShiftRequired&quot;:true},{&quot;eventKey&quot;:&quot;˘&quot;,&quot;eventCode&quot;:&quot;KeyH&quot;,&quot;isShiftRequired&quot;:true},{&quot;eventKey&quot;:&quot;H&quot;,&quot;isShiftRequired&quot;:true}]"
+        data-target="/?ref_&#x3D;nav_assist"
+        aria-label="Home, shift, Option, h"
+      >
+      <div class="keyboard-shortcut-container" aria-hidden="true">
+        <span class="shortcut-name nav-assistant-card-font">Home</span>
+        <div class="shortcut-keys-container" dir="ltr">
+            <span class="shortcut-key nav-assistant-card-font font-color">Shift</span>
+            <span class="plus-sign-color">+</span>
+            <span class="shortcut-key nav-assistant-card-font font-color">Opt</span>
+            <span class="plus-sign-color">+</span>
+            <span class="shortcut-key nav-assistant-card-font font-color">H</span>
+            
+        </div>
+      </div>
+      </a>
+    </li>
+    <li class="nav-assistant-list-item">
+      <a
+        id="nav-assist-your-orders"
+        role="link"
+        tabindex="-1"
+        class="nav-assistant-menu-item nav-assistant-link-item nav-assistant-keyboard-shortcut-item keyboard-shortcut-menu-container a-color-base a-color-link "
+        data-nav-assist-menu-item-index="4"
+        data-behavior="navigate"
+        
+        data-actuators="[{&quot;eventKey&quot;:&quot;Ø&quot;,&quot;eventCode&quot;:&quot;KeyO&quot;,&quot;isShiftRequired&quot;:true},{&quot;eventKey&quot;:&quot;Œ&quot;,&quot;eventCode&quot;:&quot;KeyO&quot;,&quot;isShiftRequired&quot;:true},{&quot;eventKey&quot;:&quot;O&quot;,&quot;isShiftRequired&quot;:true}]"
+        data-target="/gp/css/order-history/?ref_&#x3D;nav_assist"
+        aria-label="Your orders, shift, Option, o"
+      >
+      <div class="keyboard-shortcut-container" aria-hidden="true">
+        <span class="shortcut-name nav-assistant-card-font">Orders</span>
+        <div class="shortcut-keys-container" dir="ltr">
+            <span class="shortcut-key nav-assistant-card-font font-color">Shift</span>
+            <span class="plus-sign-color">+</span>
+            <span class="shortcut-key nav-assistant-card-font font-color">Opt</span>
+            <span class="plus-sign-color">+</span>
+            <span class="shortcut-key nav-assistant-card-font font-color">O</span>
+            
+        </div>
+      </div>
+      </a>
+    </li>
+    <li class="nav-assistant-list-item">
+      <button
+        id="nav-assist-show-shortcuts"
+        role="button"
+        tabindex="-1"
+        class="nav-assistant-menu-item nav-assistant-link-item nav-assistant-keyboard-shortcut-item keyboard-shortcut-menu-container a-color-base a-color-link nav-assistant-link-button"
+        data-nav-assist-menu-item-index="5"
+        data-behavior="show-hide"
+        
+        data-actuators="[{&quot;eventKey&quot;:&quot;¸&quot;,&quot;eventCode&quot;:&quot;KeyZ&quot;,&quot;isShiftRequired&quot;:true},{&quot;eventKey&quot;:&quot;ˇ&quot;,&quot;eventCode&quot;:&quot;KeyY&quot;,&quot;isShiftRequired&quot;:true},{&quot;eventKey&quot;:&quot;Å&quot;,&quot;eventCode&quot;:&quot;KeyW&quot;,&quot;isShiftRequired&quot;:true},{&quot;eventKey&quot;:&quot;⁄&quot;,&quot;eventCode&quot;:&quot;KeyZ&quot;,&quot;isShiftRequired&quot;:true},{&quot;eventKey&quot;:&quot;Z&quot;,&quot;eventCode&quot;:&quot;KeyZ&quot;,&quot;isShiftRequired&quot;:true},{&quot;eventKey&quot;:&quot;Z&quot;,&quot;eventCode&quot;:&quot;KeyY&quot;,&quot;isShiftRequired&quot;:true},{&quot;eventKey&quot;:&quot;Z&quot;,&quot;eventCode&quot;:&quot;KeyW&quot;,&quot;isShiftRequired&quot;:true},{&quot;eventKey&quot;:&quot;Z&quot;,&quot;isShiftRequired&quot;:true}]"
+        data-target="a[data-nav-assist-menu-item-index&#x3D;&quot;0&quot;]"
+        aria-label="Show/hide shortcuts, shift, Option, z"
+      >
+      <div class="keyboard-shortcut-container" aria-hidden="true">
+        <span class="shortcut-name nav-assistant-card-font">Show/Hide shortcuts</span>
+        <div class="shortcut-keys-container" dir="ltr">
+            <span class="shortcut-key nav-assistant-card-font font-color">Shift</span>
+            <span class="plus-sign-color">+</span>
+            <span class="shortcut-key nav-assistant-card-font font-color">Opt</span>
+            <span class="plus-sign-color">+</span>
+            <span class="shortcut-key nav-assistant-card-font font-color">Z</span>
+            
+        </div>
+      </div>
+      </button>
+    </li>
+  </ul>
+  <div
+    id="nav-assist-shortcut-help"
+  >
+    <div class="shortcut-help-container">
+      <div class="shortcut-help-item-container">
+        <div class="icon-container"><i class="a-icon a-icon-info a-icon-mini shortcut-help-icon"></i></div>
+        <div class="help-text-container">
+          <span class="shortcut-help-text font-color">To move between items, use your keyboard&#x27;s up or down arrows.</span>
+        </div>
+      </div>
+    </div>
+  </div>
+</nav>
+
+
+
+
+
+<script type='text/javascript'>window.navmet.main=+new Date();</script>
+
+
+
+<header id="navbar-main" class = "nav-opt-sprite nav-flex nav-locale-ca nav-lang-en nav-ssl nav-rec nav-progressive-attribute">
+
+   
+  <div id='navbar' cel_widget_id='Navigation-desktop-navbar'
+  role='navigation' class="nav-sprite-v1 celwidget nav-bluebeacon nav-a11y-t1 bold-focus-hover layout2 nav-flex layout3 layout3-alt nav-packard-glow hamburger nav-progressive-attribute" aria-label="Primary">
+    <div id='nav-belt'>
+      <div class='nav-left'>
+        <script type='text/javascript'>window.navmet.tmp=+new Date();</script>
+  <div id="nav-logo" class="nav-prime-1 nav-progressive-attribute">
+    <a href="/ref=nav_logo" id="nav-logo-sprites" class="nav-logo-link nav-progressive-attribute" aria-label="Amazon.ca Prime" lang="en" >
+      <span class="nav-sprite nav-logo-base"></span>
+      <span id="logo-ext" class="nav-sprite nav-logo-ext nav-progressive-content"></span>
+      <span class="nav-logo-locale">.ca</span>
+    </a>
+ <div id="nav-tagline" class="nav-progressive-content">
+  <a href="/ref=nav_logo_prime" tabindex="-1"  class="nav-sprite nav-logo-tagline">
+    
+  </a>
+</div>
+  </div>
+<script type='text/javascript'>window.navmet.push({key:'Logo',end:+new Date(),begin:window.navmet.tmp});</script>
+        
+<div id="nav-global-location-slot">
+    <span id="nav-global-location-data-modal-action" class="a-declarative nav-progressive-attribute" data-a-modal='{&quot;width&quot;:375, &quot;closeButton&quot;:&quot;true&quot;,&quot;popoverLabel&quot;:&quot;Choose your location&quot;, &quot;ajaxHeaders&quot;:{&quot;anti-csrftoken-a2z&quot;:&quot;hGJ5YKMmnMWVM/VgfvHQQZaiRmdj+qRnOcMVq6DX43+WAAAAAGhJmy8AAAAB&quot;}, &quot;name&quot;:&quot;glow-modal&quot;, &quot;url&quot;:&quot;/portal-migration/hz/glow/get-rendered-address-selections?deviceType&#x3D;desktop&amp;pageType&#x3D;AmazonFamilyDigitalOrderApplication&amp;storeContext&#x3D;NoStoreName&amp;actionSource&#x3D;desktop-modal&quot;, &quot;footer&quot;:null,&quot;header&quot;:&quot;Choose your location&quot;}' data-action="a-modal">
+        <a id="nav-global-location-popover-link" role="button" tabindex="0" class="nav-a nav-a-2 a-popover-trigger a-declarative nav-progressive-attribute" href="">
+            <div class="nav-sprite nav-progressive-attribute" id="nav-packard-glow-loc-icon"></div>
+            <div id="glow-ingress-block">
+                <span class="nav-line-1 nav-progressive-content" id="glow-ingress-line1">
+                   Deliver to Pooja
+                </span>
+                <span class="nav-line-2 nav-progressive-content" id="glow-ingress-line2">
+                   Waterloo N2V 0G&zwnj;
+                </span>
+            </div>
+        </a>
+        </span>
+        <input data-addnewaddress="add-new" id="unifiedLocation1ClickAddress" name="dropdown-selection" type="hidden" value="nknlnworkmkq" class="nav-progressive-attribute" />
+        <input data-addnewaddress="add-new" id="ubbShipTo" name="dropdown-selection-ubb" type="hidden" value="nknlnworkmkq" class="nav-progressive-attribute"/>
+        <input id="glowValidationToken" name="glow-validation-token" type="hidden" value="hGJ5YKMmnMWVM/VgfvHQQZaiRmdj+qRnOcMVq6DX43+WAAAAAGhJmy8AAAAB" class="nav-progressive-attribute"/>
+        <input id="glowDestinationType" name="glow-destination-type" type="hidden" value="DEFAULT_ADDRESS" class="nav-progressive-attribute"/>
+</div>
+
+<div id="nav-global-location-toaster-script-container" class="nav-progressive-content">
+</div>
+
+      </div>
+          <div class='nav-fill' id='nav-fill-search'>
+            <script type='text/javascript'>window.navmet.tmp=+new Date();</script>
+<div id="nav-search">
+  <div id="nav-bar-left"></div> 
+  <form
+    id="nav-search-bar-form"
+    accept-charset="utf-8"
+    action="/s/ref=nb_sb_noss"
+    class="nav-searchbar nav-progressive-attribute"
+    method="GET"
+    name="site-search"
+    role="search"
+  >
+
+    <div class="nav-left">
+      <div id="nav-search-dropdown-card">
+        
+  <div class="nav-search-scope nav-sprite">
+    <div class="nav-search-facade" data-value="search-alias=aps">
+      <span id="nav-search-label-id" class="nav-search-label nav-progressive-content">All</span>
+      <i class="nav-icon"></i>
+    </div>
+    <label id="searchDropdownDescription" for="searchDropdownBox" class="nav-progressive-attribute" style="display:none">Select the department you want to search in</label>
+    <select
+      aria-describedby="searchDropdownDescription"
+      class="nav-search-dropdown searchSelect nav-progressive-attrubute nav-progressive-search-dropdown"
+      data-nav-digest="nneq7nrNqOYsVCon5kGnB6328gE="
+      data-nav-selected="0"
+      id="searchDropdownBox"
+      name="url"
+      style="display: block;"
+      tabindex="0"
+      title="Search in"
+    >
+        <option selected="selected" value="search-alias=aps">All Departments</option>
+        <option value="search-alias=alexa-skills">Alexa Skills</option>
+        <option value="search-alias=amazon-devices">Amazon Devices</option>
+        <option value="search-alias=warehouse-deals">Amazon Resale</option>
+        <option value="search-alias=mobile-apps">Apps & Games</option>
+        <option value="search-alias=audible">Audible Audiobooks</option>
+        <option value="search-alias=automotive">Automotive</option>
+        <option value="search-alias=baby">Baby</option>
+        <option value="search-alias=beauty">Beauty</option>
+        <option value="search-alias=stripbooks">Books</option>
+        <option value="search-alias=fashion">Clothing, Shoes & Jewellery</option>
+        <option value="search-alias=fashion-womens">Women's Clothing, Shoes & Jewellery</option>
+        <option value="search-alias=fashion-mens">Men's Clothing, Shoes & Jewellery</option>
+        <option value="search-alias=fashion-girls">Girl's Clothing, Shoes & Jewellery</option>
+        <option value="search-alias=fashion-boys">Boy's Clothing, Shoes & Jewellery</option>
+        <option value="search-alias=fashion-baby">Baby Clothing, Shoes and Jewellery</option>
+        <option value="search-alias=electronics">Electronics</option>
+        <option value="search-alias=gift-cards">Gift Cards</option>
+        <option value="search-alias=grocery">Grocery</option>
+        <option value="search-alias=handmade">Handmade</option>
+        <option value="search-alias=hpc">Health & Personal Care</option>
+        <option value="search-alias=kitchen">Home & Kitchen</option>
+        <option value="search-alias=industrial">Industrial & Scientific</option>
+        <option value="search-alias=digital-text">Kindle Store</option>
+        <option value="search-alias=fashion-luggage">Luggage & Travel Gear</option>
+        <option value="search-alias=luxury-beauty">Luxury Beauty</option>
+        <option value="search-alias=dvd">Movies & TV</option>
+        <option value="search-alias=digital-music">MP3 Music</option>
+        <option value="search-alias=popular">Music</option>
+        <option value="search-alias=mi">Musical Instruments, Stage & Studio</option>
+        <option value="search-alias=office-products">Office Products</option>
+        <option value="search-alias=lawngarden">Patio, Lawn & Garden</option>
+        <option value="search-alias=pets">Pet Supplies</option>
+        <option value="search-alias=instant-video">Prime Video</option>
+        <option value="search-alias=smart-home">Smart Home</option>
+        <option value="search-alias=software">Software</option>
+        <option value="search-alias=sporting">Sports & Outdoors</option>
+        <option value="search-alias=specialty-aps-sns">Subscribe & Save</option>
+        <option value="search-alias=tools">Tools & Home Improvement</option>
+        <option value="search-alias=toys">Toys & Games</option>
+        <option value="search-alias=videogames">Video Games</option>
+    </select>
+  </div>
+
+      </div>
+    </div>
+    <div class="nav-fill">
+      <div class="nav-search-field ">
+          <label for="twotabsearchtextbox" style="display: none;">Search Amazon.ca</label>
+          <input
+            type="text"
+            id="twotabsearchtextbox"
+            value=""
+            name="field-keywords"
+            autocomplete="off"
+            placeholder="Search Amazon.ca"
+            class="nav-input nav-progressive-attribute"
+            dir="auto"
+            tabindex="0"
+            aria-label="Search Amazon.ca"
+            role="searchbox"
+            aria-autocomplete="list"
+            aria-controls="sac-autocomplete-results-container"
+            aria-expanded="false"
+            aria-haspopup="grid"
+            spellcheck="false"
+          >
+      </div>
+      <div id="nav-iss-attach"></div>
+    </div>
+    <div class="nav-right">
+      <div class="nav-search-submit nav-sprite">
+        <span id="nav-search-submit-text" class="nav-search-submit-text nav-sprite nav-progressive-attribute" aria-label="Go">
+          <input id="nav-search-submit-button" type="submit" class="nav-input nav-progressive-attribute" value="Go" tabindex="0">
+        </span>
+      </div>
+    </div>
+  </form>
+</div>
+<script type='text/javascript'>window.navmet.push({key:'Search',end:+new Date(),begin:window.navmet.tmp});</script>
+          </div>
+      <div class='nav-right'>
+          <script type='text/javascript'>window.navmet.tmp=+new Date();</script>
+          <div id='nav-tools' class="layoutToolbarPadding">
+              
+              
+              
+              
+  <div class="nav-div" id="icp-nav-flyout">
+  <a href="/customer-preferences/edit?ie=UTF8&preferencesReturnUrl=%2F&ref_=topnav_lang" class="nav-a nav-a-2 icp-link-style-2" aria-label="Choose a language for shopping in Amazon Canada. The current selection is English (EN).
+">
+    <span class="icp-nav-link-inner">
+      <span class="nav-line-1">
+      </span>
+      <span class="nav-line-2">
+         <span class="icp-nav-flag icp-nav-flag-ca icp-nav-flag-lop" role="img" aria-label="Canada"></span>
+          <div>EN</div>
+      </span>
+    </span>
+  </a>
+  <button class="nav-flyout-button nav-icon nav-arrow" aria-label="Expand to Change Language or Country" tabindex=0></button>
+</div>
+
+              
+  <div class="nav-div" id="nav-link-accountList">
+  <a href="https://www.amazon.ca/gp/css/homepage.html?ref_=nav_youraccount_btn" class="nav-a nav-a-2 nav-truncate   nav-progressive-attribute" data-nav-ref="nav_youraccount_btn"  data-nav-role="signin" data-ux-jq-mouseenter="true" tabindex="0" data-csa-c-type="link" data-csa-c-slot-id="nav-link-accountList" data-csa-c-content-id="nav_youraccount_btn"  aria-controls="nav-flyout-accountList" >
+  <div class="nav-line-1-container"><span id="nav-link-accountList-nav-line-1" class="nav-line-1 nav-progressive-content">Hello, Pooja</span></div>
+  <span class="nav-line-2 ">Account & Lists
+  </span>
+  </a>
+  <button class="nav-flyout-button nav-icon nav-arrow" aria-label="Expand Account and Lists" tabindex=0></button>
+  </div>
+
+              
+<a href="/gp/css/order-history?ref_=nav_orders_first" class="nav-a nav-a-2   nav-progressive-attribute" id="nav-orders" tabindex="0">
+  <span class="nav-line-1">Returns</span>
+  <span class="nav-line-2">& Orders<span class="nav-icon nav-arrow"></span></span>
+</a>
+
+              
+              
+  <a href="/gp/cart/view.html?ref_=nav_cart" aria-label="4 items in cart" class="nav-a nav-a-2 nav-progressive-attribute" id="nav-cart">
+    <div id="nav-cart-count-container">
+      <span id="nav-cart-count" aria-hidden="true" class="nav-cart-count nav-cart-1 nav-progressive-attribute nav-progressive-content">4</span>
+      <span class="nav-cart-icon nav-sprite"></span>
+    </div>
+    <div id="nav-cart-text-container" class=" nav-progressive-attribute">
+      <span aria-hidden="true" class="nav-line-1">
+         
+      </span>
+      <span aria-hidden="true" class="nav-line-2">
+        Cart
+        <span class="nav-icon nav-arrow"></span>
+      </span>
+    </div>
+  </a>
+
+          </div>
+          <script type='text/javascript'>window.navmet.push({key:'Tools',end:+new Date(),begin:window.navmet.tmp});</script>
+
+      </div>
+    </div>
+    <div id='nav-belt-search' class='nav-fill'></div>
+    <div id='nav-main' class='nav-sprite'>
+      <div class='nav-left'>
+        <script type='text/javascript'>window.navmet.tmp=+new Date();</script>
+  <a href="/gp/site-directory?ref_=nav_em_js_disabled" id="nav-hamburger-menu" role="button" aria-label="Open All Categories Menu" aria-expanded="false" data-csa-c-type="widget" data-csa-c-slot-id="HamburgerMenuDesktop"
+  data-csa-c-interaction-events="click" >
+    <i class="hm-icon nav-sprite"></i>
+    <span class="hm-icon-label">All</span>
+  </a>
+  
+<script type="text/javascript">
+  var hmenu = document.getElementById("nav-hamburger-menu");
+  hmenu.setAttribute("href", "javascript: void(0)");
+  window.navHamburgerMetricLogger = function() {
+    if (window.ue && window.ue.count) {
+      var metricName = "Nav:Hmenu:IconClickActionPending";
+      window.ue.count(metricName, (ue.count(metricName) || 0) + 1);
+    }
+    window.$Nav && $Nav.declare("navHMenuIconClicked",!0);
+    window.$Nav && $Nav.declare("navHMenuIconClickedNotReadyTimeStamp", Date.now());
+  };
+  hmenu.addEventListener("click", window.navHamburgerMetricLogger);
+  window.$Nav && $Nav.declare('hamburgerMenuIconAvailableOnLoad', false);
+</script>  
+<script type='text/javascript'>window.navmet.push({key:'HamburgerMenuIcon',end:+new Date(),begin:window.navmet.tmp});</script>
+        
+        
+      </div>
+      <div class='nav-fill'>
+        
+ <div id="nav-shop">
+ </div>
+        <div id='nav-xshop-container'>
+          <div id='nav-xshop' class="nav-progressive-content">
+            <script type='text/javascript'>window.navmet.tmp=+new Date();</script>
+  <ul class="nav-ul">
+      
+<li class="nav-li">
+<div class="nav-div">
+<a href="/b/?node=205737042011&ref_=nav_cs_cml_desk_disco" class="nav-a  " tabindex="0" data-csa-c-type="link" data-csa-c-slot-id="nav_cs_0" data-csa-c-content-id="nav_cs_cml_desk_disco">Customers' Most-Loved</a>
+</div>
+</li>
+
+
+<li class="nav-li">
+<div class="nav-div">
+<a href="/gp/help/customer/display.html?ref_=nav_cs_help" class="nav-a  " tabindex="0" data-csa-c-type="link" data-csa-c-slot-id="nav_cs_1" data-csa-c-content-id="nav_cs_help">Customer Service</a>
+</div>
+</li>
+
+
+<li class="nav-li">
+<div class="nav-div">
+<a href="/gp/buyagain?ref_=nav_cs_buy_again" class="nav-a  " tabindex="0" data-csa-c-type="link" data-csa-c-slot-id="nav_cs_2" data-csa-c-content-id="nav_cs_buy_again">Buy Again</a>
+</div>
+</li>
+
+
+<li class="nav-li">
+<div class="nav-div">
+<a href="/deals?ref_=nav_cs_gb" class="nav-a  " tabindex="0" data-csa-c-type="link" data-csa-c-slot-id="nav_cs_3" data-csa-c-content-id="nav_cs_gb">Deals Store</a>
+</div>
+</li>
+
+
+<li class="nav-li">
+<div class="nav-div">
+<a href="/gp/browse.html?node=9230166011&ref_=nav_cs_gc" class="nav-a  " tabindex="0" data-csa-c-type="link" data-csa-c-slot-id="nav_cs_4" data-csa-c-content-id="nav_cs_gc">Gift Cards</a>
+</div>
+</li>
+
+
+<li class="nav-li">
+<div class="nav-div">
+<a href="/gp/history?ref_=nav_cs_timeline" class="nav-a  " tabindex="0" data-csa-c-type="link" data-csa-c-slot-id="nav_cs_5" data-csa-c-content-id="nav_cs_timeline">Browsing History</a>
+</div>
+</li>
+
+
+<li class="nav-li">
+<div class="nav-div">
+<a id="nav-your-amazon" href="/gp/yourstore/home?ref_=nav_cs_ys" class="nav-a  " tabindex="0" data-csa-c-type="link" data-csa-c-slot-id="nav_cs_6" data-csa-c-content-id="nav_cs_ys"><span id="nav-your-amazon-text"><span class="nav-shortened-name">Pooja</span>'s Store</span></a>
+</div>
+</li>
+
+
+<li class="nav-li">
+<div class="nav-div">
+<a href="/ebooks-kindle/b/?ie=UTF8&node=2980423011&ref_=nav_cs_kindle_books" class="nav-a  " tabindex="0" data-csa-c-type="link" data-csa-c-slot-id="nav_cs_7" data-csa-c-content-id="nav_cs_kindle_books">Kindle Books</a>
+</div>
+</li>
+
+
+<li class="nav-li">
+<div class="nav-div">
+<a href="/Best-Sellers-generic/zgbs/?ref_=nav_cs_bestsellers" class="nav-a  " tabindex="0" data-csa-c-type="link" data-csa-c-slot-id="nav_cs_8" data-csa-c-content-id="nav_cs_bestsellers">Best Sellers</a>
+</div>
+</li>
+
+
+<li class="nav-li">
+<div class="nav-div">
+<a href="/books-used-books-textbooks/b/?ie=UTF8&node=916520&ref_=nav_cs_books" class="nav-a  " tabindex="0" data-csa-c-type="link" data-csa-c-slot-id="nav_cs_9" data-csa-c-content-id="nav_cs_books">Books</a>
+</div>
+</li>
+
+
+<li class="nav-li">
+<div class="nav-div">
+<a href="/gcx/-/gfhz/?ref_=nav_cs_giftfinder" class="nav-a  " tabindex="0" data-csa-c-type="link" data-csa-c-slot-id="nav_cs_10" data-csa-c-content-id="nav_cs_giftfinder">Gift Ideas	</a>
+</div>
+</li>
+
+
+<li class="nav-li">
+<div class="nav-div">
+<a href="/gp/new-releases/?ref_=nav_cs_newreleases" class="nav-a  " tabindex="0" data-csa-c-type="link" data-csa-c-slot-id="nav_cs_11" data-csa-c-content-id="nav_cs_newreleases">New Releases</a>
+</div>
+</li>
+
+
+<li class="nav-li">
+<div class="nav-div">
+<a href="/gp/browse.html?node=2206275011&ref_=nav_cs_home" class="nav-a  " tabindex="0" data-csa-c-type="link" data-csa-c-slot-id="nav_cs_12" data-csa-c-content-id="nav_cs_home">Home</a>
+</div>
+</li>
+
+
+<li class="nav-li">
+<div class="nav-div">
+<a href="/Health-Personal-Care/b/?ie=UTF8&node=6205177011&ref_=nav_cs_hpc" class="nav-a  " tabindex="0" data-csa-c-type="link" data-csa-c-slot-id="nav_cs_13" data-csa-c-content-id="nav_cs_hpc">Health & Household</a>
+</div>
+</li>
+
+
+<li class="nav-li">
+<div class="nav-div">
+<a href="/Beauty/b/?ie=UTF8&node=6205124011&ref_=nav_cs_beauty" class="nav-a  " tabindex="0" data-csa-c-type="link" data-csa-c-slot-id="nav_cs_14" data-csa-c-content-id="nav_cs_beauty">Beauty & Personal Care</a>
+</div>
+</li>
+
+
+<li class="nav-li">
+<div class="nav-div" id="nav-link-amazonprime">
+<a href="/prime?ref_=nav_cs_primelink_member" class="nav-a  " data-ux-jq-mouseenter="true" tabindex="0"  data-csa-c-type="link" data-csa-c-slot-id="nav-link-amazonprime" data-csa-c-content-id="nav_cs_primelink_member"><span>Prime</span>
+</a>
+<button aria-expanded="false" class="nav-flyout-button nav-icon nav-arrow" aria-label="Prime Details" tabindex=0></button>
+</div>
+</li>
+
+<li class="nav-li">
+<div class="nav-div">
+<a href="/video-games-hardware-accessories/b/?ie=UTF8&node=3198031&ref_=nav_cs_video_games" class="nav-a  " tabindex="0" data-csa-c-type="link" data-csa-c-slot-id="nav_cs_16" data-csa-c-content-id="nav_cs_video_games">Computer & Video Games</a>
+</div>
+</li>
+
+
+<li class="nav-li">
+<div class="nav-div">
+<a href="/gp/browse.html?node=21204935011&ref_=nav_cs_fashion" class="nav-a  " tabindex="0" data-csa-c-type="link" data-csa-c-slot-id="nav_cs_17" data-csa-c-content-id="nav_cs_fashion">Fashion</a>
+</div>
+</li>
+
+
+<li class="nav-li">
+<div class="nav-div">
+<a href="/Computers-Accessories/b/?ie=UTF8&node=2404990011&ref_=nav_cs_pc" class="nav-a  " tabindex="0" data-csa-c-type="link" data-csa-c-slot-id="nav_cs_18" data-csa-c-content-id="nav_cs_pc">Computers</a>
+</div>
+</li>
+
+
+<li class="nav-li">
+<div class="nav-div">
+<a href="/Home-Improvement/b/?ie=UTF8&node=3006902011&ref_=nav_cs_hi" class="nav-a  " tabindex="0" data-csa-c-type="link" data-csa-c-slot-id="nav_cs_19" data-csa-c-content-id="nav_cs_hi">Home Improvement</a>
+</div>
+</li>
+
+
+<li class="nav-li">
+<div class="nav-div">
+<a href="/automotive/b/?ie=UTF8&node=6948389011&ref_=nav_cs_automotive" class="nav-a  " tabindex="0" data-csa-c-type="link" data-csa-c-slot-id="nav_cs_20" data-csa-c-content-id="nav_cs_automotive">Automotive</a>
+</div>
+</li>
+
+
+<li class="nav-li">
+<div class="nav-div">
+<a href="/gp/browse.html?node=20037536011&ref_=nav_cs_audible" class="nav-a  " tabindex="0" data-csa-c-type="link" data-csa-c-slot-id="nav_cs_21" data-csa-c-content-id="nav_cs_audible">Audible</a>
+</div>
+</li>
+
+
+<li class="nav-li">
+<div class="nav-div">
+<a href="/Toys-Games/b/?ie=UTF8&node=6205517011&ref_=nav_cs_toys" class="nav-a  " tabindex="0" data-csa-c-type="link" data-csa-c-slot-id="nav_cs_22" data-csa-c-content-id="nav_cs_toys">Toys & Games</a>
+</div>
+</li>
+
+
+<li class="nav-li">
+<div class="nav-div">
+<a href="/sporting-goods/b/?ie=UTF8&node=2242989011&ref_=nav_cs_sports" class="nav-a  " tabindex="0" data-csa-c-type="link" data-csa-c-slot-id="nav_cs_23" data-csa-c-content-id="nav_cs_sports">Sports & Outdoors</a>
+</div>
+</li>
+
+
+<li class="nav-li">
+<div class="nav-div">
+<a href="/pet-supplies-dog-cat-food-bed-toy/b/?ie=UTF8&node=6205514011&ref_=nav_cs_pets" class="nav-a  " tabindex="0" data-csa-c-type="link" data-csa-c-slot-id="nav_cs_24" data-csa-c-content-id="nav_cs_pets">Pet Supplies</a>
+</div>
+</li>
+
+
+<li class="nav-li">
+<div class="nav-div">
+<a href="/gp/browse.html?node=3561346011&ref_=nav_cs_baby" class="nav-a  " tabindex="0" data-csa-c-type="link" data-csa-c-slot-id="nav_cs_25" data-csa-c-content-id="nav_cs_baby">Baby</a>
+</div>
+</li>
+
+
+<li class="nav-li">
+<div class="nav-div">
+<a href="/Electronics-Accessories/b/?ie=UTF8&node=667823011&ref_=nav_cs_electronics" class="nav-a  " tabindex="0" data-csa-c-type="link" data-csa-c-slot-id="nav_cs_26" data-csa-c-content-id="nav_cs_electronics">Electronics</a>
+</div>
+</li>
+
+
+<li class="nav-li">
+<div class="nav-div">
+<a href="/b/?node=15664730011&ld=AZCASOA-sell&ref_=nav_cs_sell" class="nav-a  " tabindex="0" data-csa-c-type="link" data-csa-c-slot-id="nav_cs_27" data-csa-c-content-id="nav_cs_sell">Sell</a>
+</div>
+</li>
+
+
+<li class="nav-li">
+<div class="nav-div">
+<a href="/coupons?ref_=nav_cs_coupons" class="nav-a  " tabindex="0" data-csa-c-type="link" data-csa-c-slot-id="nav_cs_28" data-csa-c-content-id="nav_cs_coupons">Coupons</a>
+</div>
+</li>
+
+
+<li class="nav-li">
+<div class="nav-div">
+<a href="/gp/browse.html?node=19700946011&ref_=nav_cs_registry" class="nav-a  " tabindex="0" data-csa-c-type="link" data-csa-c-slot-id="nav_cs_29" data-csa-c-content-id="nav_cs_registry">Registry</a>
+</div>
+</li>
+
+
+<li class="nav-li">
+<div class="nav-div">
+<a href="/grocery/b/?ie=UTF8&node=6967215011&ref_=nav_cs_grocery" class="nav-a  " tabindex="0" data-csa-c-type="link" data-csa-c-slot-id="nav_cs_30" data-csa-c-content-id="nav_cs_grocery">Grocery</a>
+</div>
+</li>
+
+
+  </ul>
+  <script type='text/javascript'>window.navmet.push({key:'CrossShop',end:+new Date(),begin:window.navmet.tmp});</script>
+          </div>
+        </div>
+      </div>
+      <div class='nav-right'>
+        <script type='text/javascript'>window.navmet.tmp=+new Date();</script><!-- Navyaan SWM -->
+<div id="nav-swmslot" class="nav-swm-text-widget">
+  <a href="/b/?_encoding=UTF8&node=37219708011&ref_=nav_swm_undefined&pf_rd_p=06bbaca6-382a-4f97-8cfc-0b134b21438d&pf_rd_s=nav-sitewide-msg&pf_rd_t=4201&pf_rd_i=navbar-4201&pf_rd_m=A2EUQ1WTGCTBG2&pf_rd_r=D32ZY1PB3E90Y6D0E1G7" id="swm-link" class="nav_a nav-swm-text nav-progressive-attribute nav-progressive-content">Discover Canada Showcase</a>
+</div><script type='text/javascript'>window.navmet.push({key:'SWM',end:+new Date(),begin:window.navmet.tmp});</script>
+      </div>
+    </div>
+
+    <div id='nav-subnav-toaster'></div>
+
+    
+    <div id="nav-progressive-subnav">
+      <script type='text/javascript'>window.navmet.tmp=+new Date();</script>
+
+<div id='nav-subnav'  data-category="deals">
+  
+    <a href="/gp/goldbox/?ie=UTF8&ref_=topnav_storetab_gb" class="nav-a nav-b"
+       aria-label="Today's Deals"
+ >
+    <span class="nav-a-content">
+      Today's Deals
+      
+    </span>
+  </a>
+    <a href="/b/?ie=UTF8&node=9833876011&ref_=sv_gb_1" class="nav-a"
+       aria-label="Outlet Deals"
+ >
+    <span class="nav-a-content">
+      Outlet Deals
+      
+    </span>
+  </a>
+    <a href="/b/?ie=UTF8&node=8929975011&ref_=sv_gb_2" class="nav-a"
+       aria-label="Amazon Resale"
+ >
+    <span class="nav-a-content">
+      Amazon Resale
+      
+    </span>
+  </a>
+    <a href="/b/?ie=UTF8&node=12218500011&ref_=sv_gb_3" class="nav-a"
+       aria-label="Coupons"
+ >
+    <span class="nav-a-content">
+      Coupons
+      
+    </span>
+  </a>
+    <a href="/b/?ie=UTF8&node=10235505011&ref_=sv_gb_4" class="nav-a"
+       aria-label="eBook Deals"
+ >
+    <span class="nav-a-content">
+      eBook Deals
+      
+    </span>
+  </a>
+    <a href="/Subscribe/b/?ie=UTF8&node=6583741011&ref_=sv_gb_5" class="nav-a"
+       aria-label="Subscribe & Save"
+ >
+    <span class="nav-a-content">
+      Subscribe & Save
+      
+    </span>
+  </a>
+    <a href="/super/?_encoding=UTF8&ref_=sv_gb_6" class="nav-a"
+       aria-label="Buy More & Save"
+ >
+    <span class="nav-a-content">
+      Buy More & Save
+      
+    </span>
+  </a>
+
+  <!-- nav-linktree-subnav - 'deals' -->
+</div>
+
+<script type='text/javascript'>window.navmet.push({key:'Subnav',end:+new Date(),begin:window.navmet.tmp});</script>
+    </div>
+
+    <div id='nav-flyout-ewc' class='nav-ewc-lazy-align nav-ewc-hide-head'><div class='nav-flyout-body ewc-beacon' tabindex='-1'><div class='nav-ewc-arrow'></div><div class='nav-ewc-content'></div></div></div><script type='text/javascript'>
+(function() {
+  var viewportWidth = function() {
+    return window.innerWidth ||
+      document.documentElement.clientWidth ||
+      document.body.clientWidth;
+  };
+
+  if (typeof uet === 'function') {  uet('x1', 'ewc', {wb: 1}); }
+
+  window.$Nav && $Nav.declare('config.ewc', (function() {
+    var config = {"enablePersistent":true,"viewportWidthForPersistent":1400,"isEWCLogging":1,"isEWCStateExpanded":true,"EWCStateReason":"fixed","isSmallScreenEnabled":true,"isFreshCustomer":false,"errorContent":{"html":"<div class='nav-ewc-error'><span class='nav-title'>Oops!</span><p class='nav-paragraph'>There is a problem retrieving your cart right now</p><a href='/gp/cart/view.html?ref_=nav_err_ewc_timeout' class='nav-action-button'><span class='nav-action-inner'>Your Cart</span></a></div>"},"url":"/cart/ewc/compact?hostPageType=AmazonFamilyDigitalOrderApplication&hostSubPageType=null&hostPageRID=D32ZY1PB3E90Y6D0E1G7&prerender=0","cartCount":4,"freshCartCount":0,"almCartCount":0,"primeWardrobeCartCount":0,"isCompactViewEnabled":true,"isCompactEWCRendered":true,"isWiderCompactEWCRendered":true,"EWCBrowserCacheKey":"EWC_Cache_133-7199711-5876416_A3QJNV48OOU9F8_CAD_en_CA","isContentRepainted":false,"clearCache":false,"loadFromCacheWithDelay":0,"delayRenderingTillATF":false};
+    var hasAui = window.P && window.P.AUI_BUILD_DATE;
+    var isRTLEnabled = (document.dir === 'rtl');
+    config.pinnable = config.pinnable && hasAui;
+    config.isMigrationTreatment = true;
+
+    config.flyout = (function() {
+      var navbelt = document.getElementById('nav-belt');
+      var navCart = document.getElementById('nav-cart');
+      var ewcFlyout = document.getElementById('nav-flyout-ewc');
+      var persistentClassOnBody = 'nav-ewc-persistent-hover nav-ewc-full-height-persistent-hover';
+      var flyout = {};
+
+      var getDocumentScrollTop = function() {
+        return (document.documentElement && document.documentElement.scrollTop) || document.body.scrollTop;
+      };
+
+      var isWindow = function(obj) {
+        return obj != null && obj === obj.window;
+      };
+
+      var getWindow = function(elem) {
+        return isWindow(elem) ? elem : elem.nodeType === 9 && elem.defaultView;
+      };
+
+      var getOffset = function(elem) {
+        if (elem.getClientRects && !elem.getClientRects().length) {
+          return {top: 0};
+        }
+
+        var rect = elem.getBoundingClientRect
+          ? elem.getBoundingClientRect()
+          : {top: 0};
+
+        if (rect.width || rect.height) {
+          var doc = elem.ownerDocument;
+          var win = getWindow(doc);
+          return {
+            top: rect.top + win.pageYOffset - doc.documentElement.clientTop
+          };
+        }
+        return rect;
+      };
+
+      flyout.align = function() {
+        var newTop = getOffset(navbelt).top - getDocumentScrollTop();
+        ewcFlyout.style.top = (newTop > 0 ? newTop + 'px' : 0);
+      };
+
+      flyout.hide = function() {
+        isRTLEnabled
+          ? (ewcFlyout.style.left = '')
+          : (ewcFlyout.style.right = '');
+      };
+
+      if(typeof config.isCompactEWCRendered === 'undefined') {
+        if (
+          (config.isSmallScreenEnabled && viewportWidth() < 1400) ||
+          (config.isCompactViewEnabled && viewportWidth() >= 1400)
+        ) {
+          config.isCompactEWCRendered = true;
+          config.isEWCStateExpanded = true;
+          config.url = config.url.replace("/gp/navcart/sidebar", "/cart/ewc/compact");
+        } else {
+          config.isCompactEWCRendered = false;
+        }
+      }
+
+      var viewportQualifyForPersistent = function () {
+        return (config.isCompactEWCRendered)
+          ? true
+          : viewportWidth() >= 1400;
+      }
+
+      flyout.hasQualifiedViewportForPersistent = viewportQualifyForPersistent;
+
+      var getEWCRightOffset = function() {
+        if (!config.isCompactEWCRendered) {
+          return 0;
+        }
+
+        var $navbelt = document.getElementById('nav-belt');
+        if ($navbelt === undefined || $navbelt === null) {
+          return 0;
+        }
+
+        var EWCCompactViewWidth = (config.isWiderCompactEWCRendered  && viewportWidth() >= 1280) ? 130 : 100;
+        var scrollLeft = (window.pageXOffset !== undefined)
+          ? window.pageXOffset
+          : (document.documentElement || document.body.parentNode || document.body).scrollLeft;
+        var scrollXAxis = Math.abs(scrollLeft);
+        var windowWidth = document.documentElement.clientWidth;
+        var navbeltWidth = $navbelt.offsetWidth;
+        var isPartOfNavbarNotVisible = (navbeltWidth + EWCCompactViewWidth) > windowWidth;
+
+        if (isPartOfNavbarNotVisible) {
+          return 0 - (navbeltWidth - scrollXAxis - windowWidth + EWCCompactViewWidth);
+        } else {
+          return 0;
+        }
+      }
+
+      flyout.getEWCRightOffsetCssProperty = function () {
+        return getEWCRightOffset() + 'px';
+      }
+
+      if (config.isCompactEWCRendered) {
+        persistentClassOnBody = 'nav-ewc-persistent-hover nav-ewc-compact-view';
+        if (config.isWiderCompactEWCRendered) { persistentClassOnBody += ' nav-ewc-wider-compact-view'; }
+      }
+
+      flyout.show = function() {
+        isRTLEnabled
+          ? (ewcFlyout.style.left = flyout.getEWCRightOffsetCssProperty())
+          : (ewcFlyout.style.right = flyout.getEWCRightOffsetCssProperty());
+      };
+
+      var isIOSDevice = function() {
+        return (/iPad|iPhone|iPod/.test(navigator.platform) ||
+                (navigator.platform === 'MacIntel' && navigator.maxTouchPoints > 1)) &&
+                !window.MSStream;
+      }
+
+      var checkForPersistent = function() {
+        if (!hasAui) {
+          return { result: false, reason: 'noAui' };
+        }
+        if (!config.enablePersistent) {
+          return { result: false, reason: 'config' };
+        }
+        if (!viewportQualifyForPersistent()) {
+          return { result: false, reason: 'viewport' };
+        }
+        if (isIOSDevice()) {
+          return { result: false, reason: 'iOS' };
+        }
+        if (!config.cartCount > 0) {
+          return { result: false, reason: 'emptycart' };
+        }
+        return { result: true };
+      };
+
+      flyout.ableToPersist = function() {
+        return checkForPersistent().result;
+      };
+      var persistentClassRegExp = '(?:^|\\s)' + persistentClassOnBody + '(?!\\S)';
+      flyout.applyPageLayoutForPersistent = function() {
+        if (!document.documentElement.className.match( new RegExp(persistentClassRegExp) )) {
+          document.documentElement.className += ' ' + persistentClassOnBody;
+        }
+      };
+
+      flyout.unapplyPageLayoutForPersistent = function() {
+        document.documentElement.className = document.documentElement.className.replace( new RegExp(persistentClassRegExp, 'g'), '');
+      };
+
+      flyout.persist = function() {
+        flyout.applyPageLayoutForPersistent();
+        flyout.show();
+        if (config.isCompactEWCRendered) {
+          flyout.align();
+        }
+      };
+
+      flyout.unpersist = function() {
+        flyout.unapplyPageLayoutForPersistent();
+        flyout.hide();
+      };
+      
+      var persistentCheck = checkForPersistent();
+    
+
+      var resizeCallback = function() {
+        
+        if (flyout.ableToPersist()) {
+          flyout.persist();
+        }
+        else {
+          flyout.unpersist();
+        }
+      };
+
+      flyout.bindEvents = function() {
+        if (window.addEventListener) {
+          window.addEventListener('resize', resizeCallback, false);
+          
+          if (config.isCompactEWCRendered) {
+            window.addEventListener('scroll', flyout.align, false);
+          }
+        }
+      };
+
+      flyout.unbindEvents = function() {
+        if (window.removeEventListener) {
+          window.removeEventListener('resize', resizeCallback, false);
+          
+          if (config.isCompactEWCRendered) {
+            window.removeEventListener('scroll', flyout.align, false);
+          }
+        }
+      };
+      
+      var ewcDefaultPersistence = function() {
+      
+        if (persistentCheck.result) {
+          flyout.persist();
+          if (window.ue && ue.tag) {
+            ue.tag('ewc:persist');
+          }
+        } else {
+          if (window.ue && ue.tag) {
+            ue.tag('ewc:unpersist');
+            if (persistentCheck.reason === 'noAui') {
+              ue.tag('ewc:unpersist:noAui');
+            }
+            if (persistentCheck.reason === 'viewport') {
+              ue.tag('ewc:unpersist:viewport');
+            }
+            if (persistentCheck.reason === 'emptycart') {
+              ue.tag('ewc:unpersist:emptycart');
+            }
+            if (persistentCheck.reason === 'iOS') {
+              ue.tag('ewc:unpersist:iOS');
+            }
+          }
+        }
+      };
+      
+      ewcDefaultPersistence();
+      
+      if (window.ue && ue.tag)  {
+        if (flyout.hasQualifiedViewportForPersistent()) {
+          ue.tag('ewc:bview');
+        }
+        else {
+          ue.tag('ewc:sview');
+        }
+      }
+      flyout.bindEvents();
+      flyout.cache = function () {
+    const cache = window.sessionStorage;
+    const CACHE_KEY = "EWCBrowserCacheKey";
+    const CACHE_EXPIRY = "EWCBrowserCacheExpiry"; 
+    const CACHE_VALUE = "EWCBrowserCacheValue"; 
+    const isSessionStorageValid = function () {
+        return window && cache && cache instanceof Storage;
+    };
+    const isCachePresent = function (key) {
+        return cache.length > 0 && cache.getItem(key);
+    }
+    const isValidType = function (value) {
+        // Prevents accessing empty key-value and internal methods(prototypes) of storage
+        // TODO: Log metrics for invalid access;
+        return value && value.constructor == String;
+    }
+    return {
+        getCache: function (key) {
+            const value = isCachePresent(key);
+            return (isValidType(value)) ? value : null;
+        },
+        setCache: function (key, value) {
+            const oldValue = isCachePresent(key);
+            const cacheExpiryTime = isCachePresent(CACHE_EXPIRY);
+            // Set the expiry when there's no existing cache - to prevent resetting expiry on page navigation
+            if (!cacheExpiryTime) {
+                var currentTime = new Date();
+                cache.setItem(CACHE_EXPIRY, new Date(currentTime.getTime() + 5 * 60000))
+            }
+            // TODO: Log length of old and new cache values when logMetrics is true
+            cache.setItem(key, value);
+        },
+        updateCacheAndEwcContainer: function (cacheKey, newEwcContent) {
+            const $ = $Nav.getNow("$");
+            const $currentEwc = $("#ewc-content");
+            if (!$currentEwc.length) {
+                var $content = $('#nav-flyout-ewc .nav-ewc-content');
+                $content.html(newEwcContent);
+                this.setCache(CACHE_KEY, cacheKey);
+                if (window.ue && window.ue.count) {
+                    var current = window.ue.count("ewc-init-cache") || 0;
+                    window.ue.count("ewc-init-cache", current + 1);
+                }
+            } else {
+                var $newEwcContent = $('<div />');
+                var EWC_CONTENT_BODY_SCROLL_SELECTOR = ".ewc-scroller--selected";
+                if (newEwcContent) { // 1. Updates EWC container with new HTML 
+        var domParser = new DOMParser();
+               var sandboxedEwcContent = domParser.parseFromString(newEwcContent, 'text/html');
+               var newEwcHtmlNoScript = sandboxedEwcContent.getElementById('ewc-content');
+               const $newEwcHtml = $newEwcContent.html(newEwcHtmlNoScript);
+                    const offSet = $currentEwc.find(EWC_CONTENT_BODY_SCROLL_SELECTOR).position().top - $currentEwc.find(".ewc-active-cart--selected").position().top;
+                    $currentEwc.html($newEwcHtml.html());
+                    $currentEwc.find(EWC_CONTENT_BODY_SCROLL_SELECTOR).scrollTop(offSet);
+                    if (typeof window.uex === 'function') {
+                        window.uex('ld', 'ewc-reflect-new-state', {wb: 1});
+                    }
+                } else {
+                    // 2. Fetches cached response and updates it's html with new state on EWC Update
+                    const cachedEwc = this.getCache(CACHE_VALUE);
+                    $newEwcContent = $newEwcContent[0];
+                    $(cachedEwc).map(function (elementIndex, element) {
+                         $newEwcContent.appendChild((element.id === "ewc-content") ? $currentEwc.clone()[0] : element);
+                    });
+                    newEwcContent = $newEwcContent.innerHTML;
+                    if (window.ue && window.ue.count) {
+                        var current = window.ue.count("ewc-update-cache") || 0;
+                        window.ue.count("ewc-update-cache", current + 1);
+                    }
+                }
+                $newEwcContent.remove();
+            }
+            this.setCache(CACHE_VALUE, newEwcContent);
+        },
+        removeCache: function (key) {
+            return cache.removeItem(key);
+        }
+    }
+}
+;
+      return flyout;
+    }());
+     
+     
+     
+const CACHE_KEY = "EWCBrowserCacheKey";
+const CACHE_VALUE = "EWCBrowserCacheValue"; 
+const CACHE_EXPIRY = "EWCBrowserCacheExpiry"; 
+var cache = config.flyout.cache();
+
+const isCacheValid = function () {
+  // Check for page types and tenure of the cache
+  const clearCache = config.clearCache;
+  const cacheExpiryTime = cache.getCache(CACHE_EXPIRY);
+  const isCacheExpired = new Date() > new Date(cacheExpiryTime);
+  const cacheKey = config.EWCBrowserCacheKey;
+  const oldCacheKey = cache.getCache(CACHE_KEY);
+  const isCacheValid = !clearCache && !isCacheExpired && cacheKey == oldCacheKey;
+  if (!isCacheValid && window.ue && window.ue.count) {
+    var current = window.ue.count("ewc-cache-invalidated") || 0;
+    window.ue.count("ewc-cache-invalidated", current + 1);
+  }
+  return isCacheValid;
+}
+function loadFromCache() {
+    if (window.uet && typeof window.uet === 'function') {
+        window.uet('bb', 'ewc-loaded-from-cache', {wb: 1});
+    }
+    if (cache) {
+        if (isCacheValid()) {
+            var content = cache.getCache(CACHE_VALUE);
+            if (content) {
+                var $ewcContainer = document.getElementById("nav-flyout-ewc").getElementsByClassName("nav-ewc-content")[0];
+                var $ewcContent = document.getElementById("ewc-content");
+                if ($ewcContainer && !$ewcContent) {
+                    $ewcContainer.innerHTML = content;
+                    // Execute scripts from cache
+                    const ewcJavascript = document.getElementById("ewc-content").parentNode.querySelectorAll(':scope > script');
+                    ewcJavascript.forEach(function (script) {
+                        var scriptTag = document.createElement("script");
+                        scriptTag.innerHTML = script.innerHTML;
+                        document.body.appendChild(scriptTag);
+                    });
+                    if (typeof window.uex === 'function') {
+                        window.uex('ld', 'ewc-loaded-from-cache', {wb: 1});
+                    }
+                } else if (window.ue && window.ue.count && typeof window.ue.count === 'function') {
+                    var currentFailure = window.ue.count("ewc-slow-cache") || 0;
+                    window.ue.count("ewc-slow-cache", currentFailure + 1);
+                }
+            }
+        } else {
+            cache.removeCache(CACHE_VALUE);
+            cache.removeCache(CACHE_KEY);
+            cache.removeCache(CACHE_EXPIRY);
+        }
+    }
+}
+function delayBy(delayTime) {
+    if (delayTime) {
+        window.setTimeout(function() {
+            loadFromCache();
+        }, delayTime)
+    } else {
+        loadFromCache();
+    }
+}
+if(config.delayRenderingTillATF) {
+    (window.AmazonUIPageJS ? AmazonUIPageJS : P).when('atf').execute("EverywhereCartLoadFromCacheOnAtf", function () {
+        delayBy(config.loadFromCacheWithDelay);
+    });
+} else {
+    delayBy(config.loadFromCacheWithDelay);
+}
+
+    return config;
+  }()));
+
+  if (typeof uet === 'function') {
+    uet('x2', 'ewc', {wb: 1});
+  }
+
+  if (window.ue && ue.tag) {
+    ue.tag('ewc');
+    ue.tag('ewc:prime');
+    ue.tag('ewc:cartsize:1-10');
+
+    if ( window.P && window.P.AUI_BUILD_DATE ) {
+      ue.tag('ewc:aui');
+    } else {
+      ue.tag('ewc:noAui');
+    }
+  }
+}());
+</script>
+  </div>
+
+  
+  
+
+</header>
+
+
+<script type='text/javascript'>window.navmet.push({key:'NavBar',end:+new Date(),begin:window.navmet.main});</script>
+
+
+<script type="text/javascript">
+  if (window.ue_t0) {
+    window.navmet.push({key:"NavMainPaintEnd",end:+new Date(),begin:window.ue_t0});
+    window.navmet.push({key:"NavFirstPaintEnd",end:+new Date(),begin:window.ue_t0});
+  }
+</script>
+
+
+<script type='text/javascript'>
+    <!--
+    window.$Nav && $Nav.declare('config.fixedBarBeacon',false);
+    window.$Nav && $Nav.when("data").run(function(data) { data({"freshTimeout":{"template":{"name":"flyoutError","data":{"error":{"title":"<style>#nav-flyout-fresh{width:269px;padding:0;}#nav-flyout-fresh .nav-flyout-content{padding:0;}</style><a href='/amazonfresh'><img src='https://images-na.ssl-images-amazon.com/images/G/01/omaha/images/yoda/flyout_72dpi._V270255989_.png' /></a>"}}}},"cartTimeout":{"template":{"name":"flyoutError","data":{"error":{"button":{"text":"Your Cart","url":"/gp/cart/view.html?ref_=nav_err_cart_timeout"},"title":"Oops!","paragraph":"There is a problem retrieving your cart right now"}}}},"primeTimeout":{"template":{"name":"flyoutError","data":{"error":{"title":"<a href='/gp/prime?ref_=nav_prime_btn_fb'><img src='https://images-na.ssl-images-amazon.com/images/G/15/prime/yourprime/yourprime-client-fallback._V316467452_.png' /></a>"}}}},"ewcTimeout":{"template":{"name":"flyoutError","data":{"error":{"button":{"text":"Your Cart","url":"/gp/cart/view.html?ref_=nav_err_ewc_timeout"},"title":"Oops!","paragraph":"There is a problem retrieving your cart right now"}}}},"errorWishlist":{"template":{"name":"flyoutError","data":{"error":{"button":{"text":"Your Wish List","url":"/gp/registry/wishlist/?ref_=nav_err_wishlist"},"title":"Oops!","paragraph":"There is a problem retrieving the list right now"}}}},"emptyWishlist":{"template":{"name":"flyoutError","data":{"error":{"button":{"text":"Your Wish List","url":"/gp/registry/wishlist/?ref_=nav_err_empty_wishlist"},"title":"Oops!","paragraph":"Your list is empty"}}}},"yourAccountContent":{"template":{"name":"flyoutError","data":{"error":{"button":{"text":"Your Account","url":"/gp/css/homepage.html?ref_=nav_err_youraccount"},"title":"Oops!","paragraph":"There is a problem retrieving the list right now"}}}},"shopAllTimeout":{"template":{"name":"flyoutError","data":{"error":{"paragraph":"There is a problem retrieving the list right now"}}}},"kindleTimeout":{"template":{"name":"flyoutError","data":{"error":{"paragraph":"There is a problem retrieving the list right now"}}}}}); });
+window.$Nav && $Nav.when("util.templates").run("FlyoutErrorTemplate", function(templates) {
+      templates.add("flyoutError", "<# if(error.title) { #><span class='nav-title'><#=error.title #></span><# } #><# if(error.paragraph) { #><p class='nav-paragraph'><#=error.paragraph #></p><# } #><# if(error.button) { #><a href='<#=error.button.url #>' class='nav-action-button' ><span class='nav-action-inner'><#=error.button.text #></span></a><# } #>");
+    });
+
+    if (typeof uet == 'function') {
+    uet('bb', 'iss-init-pc', {wb: 1});
+  }
+  if (!window.$SearchJS && window.$Nav) {
+    window.$SearchJS = $Nav.make('sx');
+  }
+
+  var opts = {
+    host: "completion.amazon.com/search/complete"
+  , marketId: "7"
+  , obfuscatedMarketId: "A2EUQ1WTGCTBG2"
+  , searchAliases: []
+  , filterAliases: []
+  , pageType: "AmazonFamilyDigitalOrderApplication"
+  , requestId: "D32ZY1PB3E90Y6D0E1G7"
+  , sessionId: "133-7199711-5876416"
+  , language: "en_CA"
+  , customerId: "A3QJNV48OOU9F8"
+  , asin: ""
+  , b2b: 0
+  , fresh: 0
+  , isJpOrCn: 0
+  , isUseAuiIss: 1
+};
+
+var issOpts = {
+    fallbackFlag: 1
+  , isDigitalFeaturesEnabled: 0
+  , isWayfindingEnabled: 0
+  , dropdown: "select.searchSelect"
+  , departmentText: "in {department}"
+  , suggestionText: "Search suggestions"
+  , recentSearchesTreatment: "C"
+  , authorSuggestionText: ": all books"
+  , translatedStringsMap: {"sx-recent-searches":"Recent searches","sx-your-recent-search":"Inspired by your recent search"}
+  , biaTitleText: ""
+  , biaPurchasedText: ""
+  , biaViewAllText: ""
+  , biaViewAllManageText: ""
+  , biaAndText: ""
+  , biaManageText: ""
+  , biaWeblabTreatment: ""
+  , issNavConfig: {}
+  , np: 0
+  , issCorpus: []
+  , cf: 1
+  , removeDeepNodeISS: ""
+  , trendingTreatment: "C"
+  , useAPIV2: ""
+  , opfSwitch: ""
+  , isISSDesktopRefactorEnabled: "1"
+  , useServiceHighlighting: "true"
+  , isInternal: 0
+  , isAPICachingDisabled: true
+  , isBrowseNodeScopingEnabled: false
+  , isStorefrontTemplateEnabled: false
+  , disableAutocompleteOnFocus: ""
+};
+
+  if (opts.isUseAuiIss === 1 && window.$Nav) {
+  window.$Nav.when('sx.iss').run('iss-mason-init', function(iss){
+    var issInitObj = buildIssInitObject(opts, issOpts, true);
+    new iss.IssParentCoordinator(issInitObj);
+
+    $SearchJS.declare('canCreateAutocomplete', issInitObj);
+  });
+} else if (window.$SearchJS) {
+  var iss;
+
+  // BEGIN Deprecated globals
+  var issHost = opts.host
+    , issMktid = opts.marketId
+    , issSearchAliases = opts.searchAliases
+    , updateISSCompletion = function() { iss.updateAutoCompletion(); };
+  // END deprecated globals
+
+
+  $SearchJS.when('jQuery', 'search-js-autocomplete-lib').run('autocomplete-init', initializeAutocomplete);
+  $SearchJS.when('canCreateAutocomplete').run('createAutocomplete', createAutocomplete);
+
+} // END conditional for window.$SearchJS
+  function initializeAutocomplete(jQuery) {
+  var issInitObj = buildIssInitObject(opts, issOpts);
+  $SearchJS.declare("canCreateAutocomplete", issInitObj);
+} // END initializeAutocomplete
+  function initSearchCsl(searchCSL, issInitObject) {
+  searchCSL.init(
+    opts.pageType,
+    (window.ue && window.ue.rid) || opts.requestId
+  );
+  $SearchJS.declare("canCreateAutocomplete", issInitObject);
+} // END initSearchCsl
+  function createAutocomplete(issObject) {
+  iss = new AutoComplete(issObject);
+
+  $SearchJS.publish("search-js-autocomplete", iss);
+
+  logMetrics();
+} // END createAutocomplete
+  function buildIssInitObject(opts, issOpts, isNewIss) {
+    var issInitObj = {
+        src: opts.host
+      , sessionId: opts.sessionId
+      , requestId: opts.requestId
+      , mkt: opts.marketId
+      , obfMkt: opts.obfuscatedMarketId
+      , pageType: opts.pageType
+      , language: opts.language
+      , customerId: opts.customerId
+      , fresh: opts.fresh
+      , b2b: opts.b2b
+      , aliases: opts.searchAliases
+      , fb: issOpts.fallbackFlag
+      , isDigitalFeaturesEnabled: issOpts.isDigitalFeaturesEnabled
+      , isWayfindingEnabled: issOpts.isWayfindingEnabled
+      , issPrimeEligible: issOpts.issPrimeEligible
+      , deptText: issOpts.departmentText
+      , sugText: issOpts.suggestionText
+      , filterAliases: opts.filterAliases
+      , biaWidgetUrl: opts.biaWidgetUrl
+      , recentSearchesTreatment: issOpts.recentSearchesTreatment
+      , authorSuggestionText: issOpts.authorSuggestionText
+      , translatedStringsMap: issOpts.translatedStringsMap
+      , biaTitleText: ""
+      , biaPurchasedText: ""
+      , biaViewAllText: ""
+      , biaViewAllManageText: ""
+      , biaAndText: ""
+      , biaManageText: ""
+      , biaWeblabTreatment: ""
+      , issNavConfig: issOpts.issNavConfig
+      , cf: issOpts.cf
+      , ime: opts.isJpOrCn
+      , mktid: opts.marketId
+      , qs: opts.isJpOrCn
+      , issCorpus: issOpts.issCorpus
+      , deepNodeISS: {
+          searchAliasAccessor: function($) {
+            return (window.SearchPageAccess && window.SearchPageAccess.searchAlias()) ||
+                   $('select.searchSelect').children().attr('data-root-alias');
+          },
+          searchAliasDisplayNameAccessor: function() {
+            return (window.SearchPageAccess && window.SearchPageAccess.searchAliasDisplayName());
+          }
+        }
+      , removeDeepNodeISS: issOpts.removeDeepNodeISS
+      , trendingTreatment: issOpts.trendingTreatment
+      , useAPIV2: issOpts.useAPIV2
+      , opfSwitch: issOpts.opfSwitch
+      , isISSDesktopRefactorEnabled: issOpts.isISSDesktopRefactorEnabled
+      , useServiceHighlighting: issOpts.useServiceHighlighting
+      , isInternal: issOpts.isInternal
+      , isAPICachingDisabled: issOpts.isAPICachingDisabled
+      , isBrowseNodeScopingEnabled: issOpts.isBrowseNodeScopingEnabled
+      , isStorefrontTemplateEnabled: issOpts.isStorefrontTemplateEnabled
+      , disableAutocompleteOnFocus: issOpts.disableAutocompleteOnFocus
+      , asin: opts.asin
+    };
+  
+    // If we aren't using the new ISS then we need to add these properties
+    
+    if (!isNewIss) {
+      issInitObj.dd = issOpts.dropdown; // The element with id searchDropdownBox doesn't exist in C.
+      issInitObj.imeSpacing = issOpts.imeSpacing;
+      issInitObj.isNavInline = 1;
+      issInitObj.triggerISSOnClick = 0;
+      issInitObj.sc = 1;
+      issInitObj.np = issOpts.np;
+    }
+  
+    return issInitObj;
+  } // END buildIssInitObject
+  function logMetrics() {
+  if (typeof uet == 'function' && typeof uex == 'function') {
+      uet('be', 'iss-init-pc',
+          {
+              wb: 1
+          });
+      uex('ld', 'iss-init-pc',
+          {
+              wb: 1
+          });
+  }
+} // END logMetrics
+  
+    
+window.$Nav && $Nav.declare('config.navDeviceType','desktop');
+
+window.$Nav && $Nav.declare('config.navDebugHighres',false);
+
+window.$Nav && $Nav.declare('config.pageType','AmazonFamilyDigitalOrderApplication');
+window.$Nav && $Nav.declare('config.subPageType','null');
+
+window.$Nav && $Nav.declare('config.dynamicMenuUrl','\x2Fgp\x2Fnavigation\x2Fajax\x2Fdynamic\x2Dmenu.html');
+
+window.$Nav && $Nav.declare('config.dismissNotificationUrl','\x2Fgp\x2Fnavigation\x2Fajax\x2Fdismissnotification.html');
+
+window.$Nav && $Nav.declare('config.enableDynamicMenus',true);
+
+window.$Nav && $Nav.declare('config.isInternal',false);
+
+window.$Nav && $Nav.declare('config.isBackup',false);
+
+window.$Nav && $Nav.declare('config.isRecognized',true);
+
+window.$Nav && $Nav.declare('config.transientFlyoutTrigger','\x23nav\x2Dtransient\x2Dflyout\x2Dtrigger');
+
+window.$Nav && $Nav.declare('config.subnavFlyoutUrl','\x2Fnav\x2Fajax\x2FsubnavFlyout');
+window.$Nav && $Nav.declare('config.isSubnavFlyoutMigrationEnabled',true);
+
+window.$Nav && $Nav.declare('config.recordEvUrl','\x2Fgp\x2Fnavigation\x2Fajax\x2Frecordevent.html');
+window.$Nav && $Nav.declare('config.recordEvInterval',15000);
+window.$Nav && $Nav.declare('config.sessionId','133\x2D7199711\x2D5876416');
+window.$Nav && $Nav.declare('config.requestId','D32ZY1PB3E90Y6D0E1G7');
+
+window.$Nav && $Nav.declare('config.alexaListEnabled',false);
+
+window.$Nav && $Nav.declare('config.readyOnATF',false);
+
+window.$Nav && $Nav.declare('config.dynamicMenuArgs',{"rid":"D32ZY1PB3E90Y6D0E1G7","isFullWidthPrime":0,"isPrime":1,"dynamicRequest":1,"weblabs":"","isFreshRegionAndCustomer":"","primeMenuWidth":450});
+
+window.$Nav && $Nav.declare('config.customerName','Pooja');
+
+window.$Nav && $Nav.declare('config.customerCountryCode',null);
+
+window.$Nav && $Nav.declare('config.yourAccountPrimeURL','https\x3A\x2F\x2Fwww.amazon.ca\x2Fgp\x2Fcss\x2Forder\x2Dhistory\x2Futils\x2Ffirst\x2Dorder\x2Dfor\x2Dcustomer.html\x2Fref\x3Dya_prefetch_beacon\x3Fie\x3DUTF8\x26s\x3D133\x2D7199711\x2D5876416');
+
+window.$Nav && $Nav.declare('config.yourAccountPrimeHover',true);
+
+window.$Nav && $Nav.declare('config.searchBackState',{});
+
+window.$Nav && $Nav.declare('nav.inline');
+
+(function (i) {
+  if(window._navbarSpriteUrl) {
+    i.onload = function() {window.uet && uet('ne')};
+    i.src = window._navbarSpriteUrl;
+  }
+}(new Image()));
+
+window.$Nav && $Nav.declare('config.autoFocus',false);
+
+window.$Nav && $Nav.declare('config.responsiveTouchAgents',["ieTouch"]);
+
+window.$Nav && $Nav.declare('config.responsiveGW',false);
+
+window.$Nav && $Nav.declare('config.pageHideEnabled',false);
+
+window.$Nav && $Nav.declare('config.sslTriggerType','null');
+window.$Nav && $Nav.declare('config.sslTriggerRetry',0);
+
+window.$Nav && $Nav.declare('config.doubleCart',false);
+
+window.$Nav && $Nav.declare('config.signInOverride',false);
+
+window.$Nav && $Nav.declare('config.signInTooltip',false);
+
+window.$Nav && $Nav.declare('config.isPrimeMember',true);
+
+window.$Nav && $Nav.declare('config.packardGlowTooltip',false);
+
+window.$Nav && $Nav.declare('config.packardGlowFlyout',false);
+
+window.$Nav && $Nav.declare('config.rightMarginAlignEnabled',true);
+
+window.$Nav && $Nav.declare('config.flyoutAnimation',false);
+
+window.$Nav && $Nav.declare('config.campusActivation','null');
+
+window.$Nav && $Nav.declare('config.primeTooltip',{"url":"/gp/prime/digital-adoption/navigation-bar"});
+
+window.$Nav && $Nav.declare('config.primeDay',false);
+
+window.$Nav && $Nav.declare('config.disableBuyItAgain',false);
+
+window.$Nav && $Nav.declare('config.enableCrossShopBiaFlyout',false);
+
+window.$Nav && $Nav.declare('config.pseudoPrimeFirstBrowse',null);
+
+window.$Nav && $Nav.declare('config.csYourAccount',false);
+
+window.$Nav && $Nav.declare('config.cartFlyoutDisabled',true);
+
+window.$Nav && $Nav.declare('config.isTabletBrowser',false);
+
+window.$Nav && $Nav.declare('config.HmenuProximityArea',[200,200,200,200]);
+
+window.$Nav && $Nav.declare('config.HMenuIsProximity',true);
+
+window.$Nav && $Nav.declare('config.isPureAjaxALF',false);
+
+window.$Nav && $Nav.declare('config.accountListFlyoutRedesign',false);
+
+window.$Nav && $Nav.declare('config.navfresh',false);
+
+window.$Nav && $Nav.declare('config.isFreshRegion',false);
+
+if (window.ue && ue.tag) { ue.tag('navbar'); };
+
+window.$Nav && $Nav.declare('config.blackbelt',true);
+
+window.$Nav && $Nav.declare('config.beaconbelt',true);
+
+window.$Nav && $Nav.declare('config.accountList',true);
+
+window.$Nav && $Nav.declare('config.iPadTablet',false);
+
+window.$Nav && $Nav.declare('config.searchapiEndpoint',false);
+
+window.$Nav && $Nav.declare('config.timeline',true);
+
+window.$Nav && $Nav.declare('config.timelineAsinPriceEnabled',false);
+
+window.$Nav && $Nav.declare('config.timelineDeleteEnabled',true);
+
+window.$Nav && $Nav.declare('config.dynamicTimelineDeleteArgs','0');
+
+window.$Nav && $Nav.declare('config.extendedFlyout',false);
+
+window.$Nav && $Nav.declare('config.flyoutCloseDelay',600);
+
+window.$Nav && $Nav.declare('config.pssFlag',0);
+
+window.$Nav && $Nav.declare('config.isPrimeTooltipMigrated',false);
+
+window.$Nav && $Nav.declare('config.hashCustomerAndSessionId','9b21f92fdd049cb8d02f48b927d4c5380cf2571f');
+
+window.$Nav && $Nav.declare('config.isExportMode',false);
+
+window.$Nav && $Nav.declare('config.languageCode','en_CA');
+
+window.$Nav && $Nav.declare('config.environmentVFI','AmazonNavigationCards\x2Fdevelopment\x40B6335130002\x2DAL2_aarch64');
+
+window.$Nav && $Nav.declare('config.isHMenuBrowserCacheDisable',false);
+
+window.$Nav && $Nav.declare('config.signInUrlWithRefTag','null');
+
+window.$Nav && $Nav.declare('config.regionalStores',[]);
+
+window.$Nav && $Nav.declare('config.isALFRedesignPT2',false);
+
+window.$Nav && $Nav.declare('config.isNavALFRegistryGiftList',false);
+
+window.$Nav && $Nav.declare('config.marketplaceId','A2EUQ1WTGCTBG2');
+
+window.$Nav && $Nav.declare('config.exportTransitionState',null);
+
+window.$Nav && $Nav.declare('config.enableAeeXopFlyout',false);
+
+window.$Nav && $Nav.declare('config.isPrimeFlyoutMigrationEnabled',false);
+
+
+
+window.$Nav && $Nav.declare('config.isAjaxPaymentNotificationMigrated',false);
+
+window.$Nav && $Nav.declare('config.isAjaxPaymentSuppressNotificationMigrated',false);
+
+if (window.P && typeof window.P.declare === "function" && typeof window.P.now === "function") {
+  window.P.now('packardGlowIngressJsEnabled').execute(function(glowEnabled) {
+    if (!glowEnabled) {
+      window.P.declare('packardGlowIngressJsEnabled', true);
+    }
+  });
+  window.P.now('packardGlowStoreName').execute(function(storeName) {
+    if (!storeName) {
+      window.P.declare('packardGlowStoreName','generic');
+    }
+  });
+}
+
+window.$Nav && $Nav.declare('configComplete');
+
+    -->
+</script>
+
+
+<a id="skippedLink" tabindex="-1"></a>
+
+<script type='text/javascript'>window.navmet.MainEnd = new Date();</script>
+<script type="text/javascript">
+    if (window.ue_t0) {
+      window.navmet.push({key:"NavMainEnd",end:+new Date(),begin:window.ue_t0});
+    }
+</script>
+<!-- sp:end-feature:navbar -->
+<!-- sp:feature:configured-sitewide-before-host-atf-assets -->
+<!-- sp:end-feature:configured-sitewide-before-host-atf-assets -->
+<!-- sp:feature:host-atf -->
+
+    
+
+<div id="digitalOrderSummaryContainer">
+    
+<style type="text/css">
+
+.orderSummary .currencyINR,
+.paymentSummary .currencyINR {
+    display: inline-block;
+    background: url("https://images-na.ssl-images-amazon.com/images/G/31/common/sprites/sprite-site-wide-2.png");
+    background-repeat: no-repeat;
+    background-position: -16px -333px;
+    background-size: 320px 455px;
+    width: 7px;
+    height: 10px;
+    line-height: 10px;
+    margin-right: 1px;
+    margin-bottom: 1px;
+    vertical-align: middle;
+    font-size: 8px;
+    text-decoration: inherit;
+}
+
+.paymentSummary .total-savings-display .currencyINR {
+    background-position: 0 -378px;
+    height: 15px;
+}
+
+.paymentSummary .total-savings-display {
+    color: #B12704;
+    font-weight: 700;
+    text-rendering: optimizeLegibility;
+    font-size: 17px;
+    line-height: 1.255;
+}
+
+#digitalOrderSummaryContainer {
+    margin-left: 40px;
+    margin-right: 40px;
+    min-width: 920px;
+}
+
+</style>
+
+    
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+        
+    
+
+
+
+
+        
+
+
+
+
+  
+
+    
+    
+
+
+
+
+
+
+
+
+
+
+
+        
+        
+      
+        
+<style type="text/css">
+
+table {
+    margin-bottom: 0px;
+}
+
+td, th {
+    padding: 0px;
+}
+
+table.sample {
+    border-width: 3px 3px 3px 3px;
+    border-spacing: 0px;
+    border-style: solid solid solid solid;
+    border-color: rgb(221, 221, 204) rgb(221, 221, 204) rgb(221, 221, 204) rgb(221, 221, 204);
+    border-collapse: separate;
+}
+
+table.narrowed {
+    width : 90%
+}
+
+ul.nomarker {
+    color: black;
+    margin: 0px 0px 0px 0px;
+}
+
+ul.nomarker li {
+    list-style-type: none;
+    padding: 0px;
+    margin: 0px;
+}
+
+span.section-header {
+    font-size: 135%;
+}
+
+.mfa-message-width {
+    width: 80%;
+    margin: auto;
+}
+
+.attention-required-alert {
+    width: 90%;
+    margin: auto;
+}
+
+.attention-required-button {
+    min-width: 220px;
+}
+
+</style>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+      
+      
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+			
+
+
+
+
+
+
+
+
+			
+      
+      
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+            
+        
+
+
+    
+    
+
+<div class="orderSummary">
+<br/>
+<b class="h1">
+<nobr><a href="/gp/css/homepage/ref=ppx_od_dt_b_d_ya_link">Your Account
+
+
+
+</a></nobr> &gt;
+       <nobr><a href="/gp/your-account/order-history/ref=ppx_od_dt_b_d_yo_link">Your Orders</a></nobr> &gt
+      Order Summary #D01-9262519-8073835
+</nobr>
+</b>
+<br/>
+<br/>
+
+<br/>
+
+
+
+
+
+
+
+
+<table class="narrowed" align="center" bgcolor="#ffffff" border="0" cellpadding="0" cellspacing="0" width="90%">
+  <tr>
+    <td valign="bottom">
+      <ul class="nomarker">
+        <li>
+          <b>Amazon.ca
+ order number: </b>D01-9262519-8073835
+        </li>
+        <li>
+              <b>Order Total:
+</b>
+          
+
+      $14.99
+
+         </li>
+      </ul>
+            <li><span class="a-list-item">
+                <a class="a-link-normal a-text-bold" href="/documents/download/718a2209-43f7-4be5-831f-fe9e157c9dc8/invoice.pdf">
+                    Invoice 1
+                </a> 
+            </span></li> 
+            <li><span class="a-list-item">
+                <a class="a-link-normal a-text-bold" href="/documents/download/fdcc8aff-b522-4221-8873-dc694b986d6b/invoice.pdf">
+                    Credit note 1
+                </a> 
+            </span></li> 
+    </td>
+    <td colspan="2" align="right">
+        
+<div style="border: 1px solid #CCCC98; width: 315">
+   <div style="text-align: left; padding: 5px 5px 5px 10px">
+      <div>
+         <b> Manage Your Digital Items </b>
+      </div>
+      
+<div>
+  <b><a href="/gp/digital/fiona/manage/ref=ppx_od_dt_b_d_content_dev_462">Kindle
+</a>, <a href="/photos/ref=ppx_od_dt_b_d_prime_photo_462">Prime Photos</a>, <a href="/amazondrive/ref=ppx_od_dt_b_d_amzn_drive_462">Amazon Drive</a>, <a href="/gp/dmusic/mp3/player/ref=ppx_od_dt_b_d_music_library_462?ie=UTF8">MP3
+
+</a>, <a href="/gp/mas/your-account/myapps/ref=ppx_od_dt_b_d_apps_device_462">Apps & Devices</a>, <a href="/mycd/ref=ppx_od_dt_b_d_mycd_462">Manage Your Content and Devices</a></b>
+</div>
+
+   </div>
+</div>
+
+
+    </td>
+  </tr>
+  <tr><td><br></td><td align="right">
+  </td></tr>
+</table>
+<table class="narrowed" align="center" border="0" cellpadding="0" cellspacing="0" width="90%">
+  <tr>
+    <td align="left" colspan="1" bgcolor="#ddddcc" border="0" cellpadding="0" cellspacing="0" valign="top" width="27" >
+      <img src="https://m.media-amazon.com/images/G/15/x-locale/css/checked-icon._CB485933663_.gif" width="27" alt="" height="22" border="0" />
+    </td>
+    <td bgcolor="#ddddcc">
+      <b>Digital Order: Sept. 20 2024</b>
+    </td>
+    <td align="right" bgcolor="#ddddcc" valign="top" border="0" cellpadding="0" cellspacing="0" width="0">
+        <img src="https://m.media-amazon.com/images/G/15/x-locale/common/tan-top-right-round-corner._CB485947371_.gif" width="10" alt="" height="28" border="0" />
+    </td>
+  </tr>
+
+        
+
+
+
+
+
+
+
+    
+      <tr>
+    <td colspan="4">
+      <table class="sample" align="center" cellpadding="0" cellspacing="0" width="100%">
+        <tr>
+          <td valign="top" width="15%">
+            <table border="0" cellpadding="0" cellspacing="0" width="100%">
+              <tbody>
+                <tr>
+                  <div style="padding:10px;">
+                    
+    
+
+
+
+<b>Recipient:</b><br />Pooja Jain<br />
+
+                  </div>
+                </tr>
+              </tbody>
+            </table>
+          </td>
+          <td width="3" style="background-image: url(https://m.media-amazon.com/images/G/15/digital/sitbv3/digital_order_summary/tan-block._CB485934201_.gif)">
+            <img src="https://m.media-amazon.com/images/G/15/digital/sitbv3/digital_order_summary/tan-block._CB485934201_.gif" width="3" alt="" height="100%" border="0" />
+          </td>
+          <td>
+            <table border="0" cellpadding="0" cellspacing="0" width="100%">
+              <tr>
+                <td>
+                  <table width="100%" cellpadding="0" cellspacing="0">
+                    <tr>
+                       <td style="padding:10px">
+                            <b>Items Ordered
+</b><br>
+                       </td>
+                        <td class="a-text-right" style="padding:10px">
+                          <b>Price
+
+</b>
+                        </td>
+                    </tr>
+                    <tr>
+                      <td valign="top" style="padding:10px">
+                            
+
+    
+    <b>Prime Membership Fee </b>    <br>
+
+      Sold  By: Amazon.com.ca, Inc.<br>
+      GST/HST - 85730 5932 RT0001<br />QST - 1201187016 TQ0001<br>
+      Qty: 1<br>
+    <br>
+
+    
+                      </td>
+                        <td class="a-text-right" valign="top" style="padding:10px">
+                          
+        $14.99
+                        </td>
+                    </tr>
+
+
+                      <tr>
+                      <td colspan="3">
+                        <img src="https://m.media-amazon.com/images/G/15/digital/sitbv3/digital_order_summary/tan-block._CB485934201_.gif" width="100%" alt="" height="3" border="0" />
+                      </td>
+                    </tr>
+                  </table>
+            </td>
+        </tr>
+        <tr>
+          <td>
+            <table width="100%" cellpadding="0" cellspacing="0">
+              <tr>
+
+                <td  valign="top" align="left" style="padding:10px; width:60%;">
+                </td>
+                <td class="a-text-right" style="padding:10px; white-space: nowrap;">
+                    
+                       Item(s) Subtotal: $14.99<br>
+
+
+
+
+        ----<br>
+      
+
+
+
+    
+Total Before Tax: $14.99<br />Tax (GST/HST): $0.00<br>Tax (PST/RST/QST): $0.00<br>
+    ----<br>
+   <b>Total for this Order: $14.99</b><br>
+
+                </td>
+              </tr>
+
+            </table>
+          </td>
+        </tr>
+      </table>
+    </td>
+  </tr>
+</table>
+</td>
+</tr>
+</table>
+<br>
+
+
+</div>
+
+
+    
+    <table class="narrowed" align="center">
+        <tr>
+            <td align="left" bgcolor="#ddddcc" border="0" cellpadding="0" cellspacing="0" valign="top" width="10">
+                <img src="https://m.media-amazon.com/images/G/15/x-locale/common/tan-top-left-round-corner._CB485934687_.gif" width="10" alt="" height="28" border="0" />
+            </td>
+            <td bgcolor="#ddddcc" border="0" cellpadding="0" cellspacing="0">
+                <b>Payment Information</b>
+             </td>
+             <td class="a-text-right" bgcolor="#ddddcc" valign="top" border="0" cellpadding="0" cellspacing="0" width="0">
+
+
+                <span class="a-button a-button-base a-button-small"><span class="a-button-inner"><a href="http://www.amazon.ca/gp/digital/your-account/order-summary.html?ie=UTF8&orderID=D01-9262519-8073835&print=1" class="a-button-text" role="button">
+                    Need to print an invoice?
+                </a></span></span>
+                <img src="https://m.media-amazon.com/images/G/15/x-locale/common/tan-top-right-round-corner._CB485947371_.gif" width="10" alt="" height="28" border="0" />
+            </td>
+        </tr>
+    </table>
+
+
+
+
+
+<table class="sample narrowed" align="center" style="padding: 10px">
+    <tr>
+        <td valign="top">
+            <script type="text/javascript">//<![CDATA[
+(function(){"undefined"===typeof PaymentsPortal2&&(PaymentsPortal2={toString:function(){return"PaymentsPortal2"}});"undefined"===typeof APX&&(APX=PaymentsPortal2);if(!PaymentsPortal2.modules){var n=function(){};"undefined"!==typeof console&&console.error&&(n=function(){console.error(Array.prototype.slice.call(arguments,0).join(" "))});var l=function(){function l(b,a){var d;d=0<a.length&&"."===a.charAt(0)?b.split(/\/+/).concat(a.split(/\/+/)):a.split(/\/+/);for(var e=[],f=0,k=d.length;f<k;f++){var h=
+d[f];""!==h&&"."!==h&&(".."===h?e.pop():e.push(h))}return e.join("/")}function s(b,a){for(var d=[],e=0,f=a.length;e<f;e++)d.push(l(b,a[e]));return d}function g(b,c){delete a._loading[b];a._modules[b]=c;if(a._waiting[b]){var d=a._waiting[b];delete a._waiting[b];for(var e=0,f=d.length;e<f;e++)try{d[e](c)}catch(k){n("Callback waiting on module ["+b+"] failed: "+k)}}}function p(b){if(a._modules[b])return a._modules[b];if(a._loading[b]||!a._definitions[b])return null;var c=a._definitions[b];a._loading[b]=
+{start_time:Date.now()};m(s(b,c.deps),function(){var a=Array.prototype.slice.call(arguments,0),a=c.factory.apply(null,a);g(b,a)})}function t(b,c){a._modules[b]?c(a._modules[b]):(a._waiting[b]||(a._waiting[b]=[]),a._waiting[b].push(c),p(b))}function q(b,c){a._definitions[b]&&c.call(c)}function m(b,c,d){function e(a){return function(d){k[a]=d;f++;f>=b.length&&!h&&(h=!0,c.apply(c,k))}}if(0===b.length)c.call(c);else{for(var f=0,k=[],h=!1,g=0,l=b.length;g<l;g++){var m=b[g];k.push(null);t(m,e(g))}!0===
+d&&window.setTimeout(function(){h||(h=!0,c.apply(c,k))},a._waitMilliseconds)}}function r(b,c,d){if(a._definitions[b])return!1;a._definitions[b]={id:b,deps:c,factory:d};a._waiting[b]&&p(b)}var a=this;a._waitMilliseconds=7E3;a._modules={};a._definitions={};a._waiting={};a._loading={};g("modules",a);g("when",m);g("define",r);g("isDefined",q);a.when=m;a.define=r;a.isDefined=q};PaymentsPortal2.ModuleSystem=l;PaymentsPortal2.modules=new l}})();
+//]]></script>
+<script type="text/javascript">//<![CDATA[
+PaymentsPortal2.widgetStartTime = (new Date()).getTime();
+//]]></script>
+<script type="text/javascript">//<![CDATA[
+PaymentsPortal2.modules.when(['clog'],function(clog){clog.setConfiguration({"sushiEelLogSourceGroup":"com.amazon.eel.ApertureService.NA.Prod.ClientSideLogsData","sushiEelSourceGroup":"com.amazon.eel.ApertureService.NA.Prod.ClientSideMetricsData","isPmetLoggingOn":true,"foresterEndpoint":"https://fls-na.amazon.com/","defaultClient":"chainedLoggingClient","sushiEelEndPoint":"https://unagi-na.amazon.com/","pmetPostBackChannel":"/1/action-impressions/1/OP/payments-portal/action/","timberLoggingChannel":"/1/payments-portal-log/1/OP/","isTimberLoggingOn":true,"sushiEelLogEndPoint":"https://unagi-na.amazon.com/","isSushiEelLoggingOn":true});clog.setPmetHeaders({"method":"ViewPaymentPlanSummary","marketplaceId":"A2EUQ1WTGCTBG2","service":"PaymentsPortalWidgetService","client":"DigitalOrderDetails","session":"133-7199711-5876416","requestId":"D32ZY1PB3E90Y6D0E1G7","marketplace":"A2EUQ1WTGCTBG2"});});
+//]]></script>
+<div data-pmts-component-id="pp-wXTTv2-1" class="a-row pmts-portal-root-wG10OvAWP7CG pmts-portal-component pmts-portal-components-pp-wXTTv2-1"><div class="a-column a-span2 pmts-payment-instrument-billing-address"><div data-pmts-component-id="pp-wXTTv2-3" class="a-row a-spacing-small pmts-portal-component pmts-portal-components-pp-wXTTv2-3"><div class="a-row pmts-payments-instrument-header"><h5>Payment Methods</h5></div> <div class="a-row pmts-payments-instrument-details"><ul class="a-unordered-list a-nostyle a-vertical no-bullet-list pmts-payments-instrument-list"><li class="a-spacing-micro pmts-payments-instrument-detail-box-paystationpaymentmethod"><span class="a-list-item"><img alt="American Express" src="https://m.media-amazon.com/images/G/15/payments-portal/r1/issuer-images/amex._CB404661599_.gif" class="pmts-payment-credit-card-instrument-logo" height="23px" width="34px"><span class="a-letter-space"></span>AMEX<span class="a-letter-space"></span><span class="a-color-base">ending in 1929</span></span></li></ul></div></div><div data-pmts-component-id="pp-wXTTv2-2" class="a-row pmts-billing-address-header pmts-portal-component pmts-portal-components-pp-wXTTv2-2"><span class="a-text-bold">Billing address</span> </div><div data-pmts-component-id="pp-wXTTv2-2" class="a-row a-spacing-base pmts-billing-address-details pmts-portal-component pmts-portal-components-pp-wXTTv2-2"><ul class="a-unordered-list a-nostyle a-vertical no-bullet-list"><li class="pmts-billing-address-fullname"><span class="a-list-item">Pooja Jain</span></li><li class="pmts-billing-address-addressline1"><span class="a-list-item">713 Wood Lily Street</span></li><li class="pmts-billing-address-citystatepostalcode"><span class="a-list-item">Waterloo, Ontario N2V 0G1</span></li><li class="pmts-billing-address-countryname"><span class="a-list-item">Canada</span></li><span class="pmts-phone-number">6473838481</span></ul></div></div><div class="a-column a-span5 pmts-amount-breakdown a-span-last"><ul data-pmts-component-id="pp-wXTTv2-4" class="a-unordered-list a-nostyle a-vertical pmts-portal-component pmts-portal-components-pp-wXTTv2-4" role="list"><li><span class="a-list-item"><div class="a-row pmts-amount-breakdown-sub-totals"><div class="a-column a-span8">Item(s) Subtotal:</div><div class="a-column a-span4 a-text-right a-span-last">US$14.99</div></div></span></li><li><span class="a-list-item"><div class="a-row"><div class="a-column a-span4 a-span-last"><hr class="a-spacing-small a-spacing-top-small a-divider-normal pmts-amount-breakdown-separator"></div></div></span></li><li><span class="a-list-item"><div class="a-row pmts-amount-breakdown-sub-totals"><div class="a-column a-span8">Total Before Tax:</div><div class="a-column a-span4 a-text-right a-span-last">US$14.99</div></div></span></li><li><span class="a-list-item"><div class="a-row pmts-amount-breakdown-sub-totals"><div class="a-column a-span8">Tax (GST/HST):</div><div class="a-column a-span4 a-text-right a-span-last">US$0.00</div></div></span></li><li><span class="a-list-item"><div class="a-row pmts-amount-breakdown-sub-totals"><div class="a-column a-span8">Tax (PST/RST/QST):</div><div class="a-column a-span4 a-text-right a-span-last">US$0.00</div></div></span></li><li><span class="a-list-item"><div class="a-row"><div class="a-column a-span4 a-span-last"><hr class="a-spacing-small a-spacing-top-small a-divider-normal pmts-amount-breakdown-separator"></div></div></span></li></ul><hr class="a-spacing-small a-spacing-top-small a-divider-normal pmts-amount-breakdown-separator pmts-portal-component pmts-portal-components-pp-wXTTv2-4"><ul data-pmts-component-id="pp-wXTTv2-4" class="a-unordered-list a-nostyle a-vertical pmts-portal-component pmts-portal-components-pp-wXTTv2-4" role="list"><li><span class="a-list-item"><div class="a-row pmts-grand-order-total"><div class="a-column a-span8"><span class="a-size-medium a-text-bold">Grand Total:</span></div><div class="a-column a-span4 a-text-right a-span-last"><span class="a-size-medium a-color-price a-text-bold">US$14.99</span></div></div></span></li></ul></div></div><link rel="stylesheet" type="text/css" href="https://m.media-amazon.com/images/I/11STWhdvr1L._RC|01tEjLkP-OL.css,019qPFw1euL.css,21pZ9-tDsfL.css,01gqZiFs-tL.css,21HDv3R2PdL.css,01cq16REt9L.css,01qk4TdW33L.css,11cVF3U-9BL.css,01cxjPaaTNL.css,01-hVDOdMIL.css,01SJRGuZivL.css,21jGj3aJ6ZL.css,11HEveYPS1L.css,01hOHsbn7OL.css,01IsDXoRrML.css,21TKE6RIZ1L.css,01hIZRtcaHL.css,01NGxBoTbmL.css,01Mv8eppKAL.css,21YEXF4qitL.css,11cLw-QVpOL.css,01uakdML80L.css,01uHZesS5LL.css,11MhOiv1rNL.css,01rKSjRRIdL.css,018M3caCSzL.css,01Rgr3O5jgL.css,61uSrXS6TsL.css,01xniGkbKHL.css,01BUQQ2AAFL.css,11+KVSh5kaL.css,018GGCZ05rL.css,01RVwf5E26L.css,018QFljl9NL.css,01RKPCJHpeL.css,01gtkpxWIOL.css,012HRkWTMYL.css,01zEhgDPWUL.css,01le4Wlx71L.css,01Vp6ym5yBL.css,01NfyFypiAL.css,01x1gcd+b6L.css,31P+zT7-D5L.css,11uTQeLDHRL.css,01vSTBFdADL.css,21ezLBMPwNL.css,01X3lCf9VVL.css,01K72ZPRhdL.css,01km8-2DoPL.css,01Kz8HcbaSL.css,1192eqsMCTL.css,01735fiNhpL.css,01W9cE2pBBL.css,31PoFnBuhJL.css,01ENy2AhhHL.css,11D0kHAkKOL.css,015rKzeCvLL.css,01i7-FZ2dbL.css,016J20OFkGL.css,01NDW5IRowL.css,01Jrep1-A8L.css,013mx6I5MjL.css,01DR-IGztZL.css,01oed2b7XHL.css,21nMzYiVcGL.css,01YgiH4056L.css,01-BlL5QIGL.css,01dkJYlUMlL.css,013gNYW5EZL.css,01Xbi2zDI3L.css,01B8WX2PjrL.css,01Z42xKR4FL.css,0139uaPyFCL.css,01Gtbyceb8L.css,0167aosbt1L.css_.css"><script type="text/javascript" crossorigin="anonymous" src=https://m.media-amazon.com/images/I/01F0eSdeFgL._RC|01xmHR8sKWL.js,11zFabayDGL.js,91fkqUtq9WL.js,11CSpDABqwL.js,41LxQTONEeL.js,21xgRXB8NHL.js,01qEgqz5vWL.js,21dtKb-2hHL.js,11F9QyGQPnL.js,01BjMuhuoeL.js,018z02DgcjL.js,418ynRa1wzL.js,11A7Wnq9EHL.js,21g2ofl14yL.js,01lZiOWpXNL.js,01fxQjpFtZL.js,01QPv-sKbXL.js,715OUdatALL.js,61FsaJQqjEL.js,31lv6nhGAWL.js,01KeVI9xAiL.js,01XLCeEHWjL.js,01xfr089i8L.js,31U+nc5k74L.js,01CUisRJf+L.js,31-zTVSygjL.js,21jreDBzXtL.js,31US7UUWy2L.js,11YkNYiEQTL.js,11MwXTnABZL.js,01WyXDgSamL.js,41WvHbMKNOL.js,31dll0Vm2BL.js,41YvmA7q3ZL.js,11DeTVOqgKL.js,01roLdTw9jL.js,01Mhun3p1rL.js,016FFR4UHfL.js,01ghTmZWxzL.js,41Xj65n-S2L.js,31EP1z9hDpL.js,11ruTNcrLiL.js,01hC7uSyu5L.js,01kZ9GSpxoL.js,01m2evVOkML.js,11r3BWOCSsL.js,21jQEfa27sL.js,21Cfvltm+BL.js,01RRCzTIGEL.js,01mKFj6urxL.js,01jP+RtXLdL.js,01-m7UpNfBL.js,01Bc-x2JZsL.js,11WqFad6tmL.js,21IlxbU9t+L.js,01ABJiWqfwL.js,71hQlKQ2hAL.js,41DDeg4bagL.js,1174-niYaEL.js,01ZUNUWYXsL.js,318an0WNJbL.js,01lxWznRyaL.js,41PxWmillxL.js,11xjHR3gmYL.js,018dSiL9euL.js,01UQyGktSML.js,01xxApHnfyL.js,01IjsVt5ryL.js,01c23bnjK9L.js,01E3k-v-atL.js,01iFWiaisVL.js,116TX+5+a2L.js,41WOZM2pzCL.js,11EFMf+dQ8L.js,01S2nT9AvPL.js,41JGyDqglYL.js,11NXC-AjMGL.js,01-aaq0fL6L.js,51swxiGtoZL.js,41dJscK9D9L.js,01HlEYFZrpL.js,01LLJS-ZZLL.js,31wxE9H3EiL.js,317nowUsn-L.js,01qC+NC256L.js,31VNi6pSdEL.js,41no6A1c-YL.js,31tveDkZXqL.js,011FfRqzfjL.js,01zrYLlEn5L.js,01j3UbDYoSL.js,514IIX6-owL.js,41eBFS8IhML.js,31dBIYAAQ1L.js,21O8cpr6qsL.js,51PNvmXfcDL.js,015faUVD0cL.js_.js></script>
+<script type="text/javascript">//<![CDATA[
+(function() {
+        PaymentsPortal2.modules.when(['widget-factory'], function(wf) {
+          var options = {"testAjaxAuthenticationRequired":"false","clientId":"DigitalOrderDetails","serializedState":"4-MS3NCzuOMvI6lTv9gowNEaNUEorzAp-QHbF6cBaHs5GT50O9M7-I43amt6tDtfc_We_7ySGW0phGUk5Dw4GX5lGJwzBfIlPoFol53pG8bHzFHbfJ4wNs4ePWzEV46GM1sm3yT87RNj4q491Sy7GxQ5mw8qETmE2ELvpbZPqp3ycg2lVQSKuoSMgXYObpx8OczS2pC6n8NxAgcMPvKwh7PPOpnDGyXoEmtbbgfA71bPVdf_qyCqZWnr8yXqvOLYyDMlzs-B0BDTMZcTpAGSEvn2mwwo-cMMwpbEDK3u1LmNZnU2AkT1_jaS-rry3B32WNKtpzJu67P7wgdozoCYQuHvZOxticYT1t3FFk5tZurB1f-wvWDUpaOj3u7by0rY1lONGb1wzrFFbYeas4DAYhl7M4UAXU_yQMPzyrbqSoJZ9ORZ_2Uy5i_wCTfpDRNeqWBw_-SuNgO5-OYdzr0XgvV6Lb14xdnyIvUjynVwLGidHyGY7W5DpvFp4bLHODJ1oNP-c11NeBS7BHsJPSgD_o5hsKC07bwvsoPIi9_Abte28pwimJyGLEXERLRfrE-Dd2WFyzgZ7ecXqTNabTDZnUNVfzUI9wcwyGeIFAnzWzoUKLci9hPRn6S6GIV0hyRoDM9RVElf09FFqfvyq3CIgmB1EIPDe2pOvOwtT11eiemICBbAmJ6Juu9iBK-f9OJvtPWmf7GhAX1f7ukACBC_L--R06B94PkhPrUUYnnANUZuDA5CAuGw_Udkzc6jAFu-nzMDK4N3MmzqRkFEIbcaE8yuiQVTJ_24BKIPIUUpZ5YeIW73996BlRBJHOUCo_z4cPnKtGkE1i9x8F0IPqGGfxmg0PkVuD80QeWGITo5wgKMLsL3mizeIFDarLz-ZF72v_Nu42u0EWw8xm8Ph7YvDi7c7eUQhUG9v6FiCRu8y7QiMANhDYIM909GsmcS-sxKVOnBmiY5C6yktYLEaXZtonjFeLsR7Wr2g08xl3BSiXbI7X7F0IZax2C5xAdO97A_LGrRAlPwzYxahbWznor00wbkQeJVoRZLp_0K3-5_w-B_rUKZiqyCGiRNm8S46KqQ5cmg1-yvl6SPtgSIP2YdiFZbSxVKoNKEsrwE0kclYFCE2FtoSNrzjSQ72OdcRepVki8XuzS61jxppkYIxOWAprtIePHPjXJQPag6oyA4h6IjYZhhVNzOC2Qzh2ZOqZSBUAoVSLj0n-glr5PgoUCGT2nZluBuruqtZbpewF5LoaDfUgVm90RT8QJpSL2LTEKfqSGndiCj3gKDbEN2e9A3YJ-4dD1TupV_yFEQirAqKj1mih62BwqutBfXbDiCtth_HcdtZTqa0LBSeemC_zGlPU97r64YjTkWN_x4tZLJqNRTzPsfWUqluEb-pa5pWkdav6bWK5KRlefcYP6ABXCeRxLjbtTTr5tMhzugDBQF2v_J1FQuHTvwVMXi3qlZJWD3Rat-IIFG1rbav15BWpQ3Dn-eT1WVPKsNcF80BQjb4OMEtdNe4anbOFkKtapevqL1NAtgdEha6SMHxD12E","marketplaceId":"A2EUQ1WTGCTBG2","deviceType":"desktop","locale":"en_CA","customerId":"A3QJNV48OOU9F8","sessionId":"133-7199711-5876416","requestId":"D32ZY1PB3E90Y6D0E1G7","widgetInstanceId":"wG10OvAWP7CG","continueRequestAjaxSubstitutionEnabled":true,"clientLoggingWeblabEnabledValue":"false"};
+          var data = [{"elementReferences":{},"elementDOMEventMethodBindings":[],"data":{},"id":"pp-wXTTv2-3","elementReferenceTagType":{},"type":"PaymentInstrumentComponent"},{"elementReferences":{},"elementDOMEventMethodBindings":[],"data":{},"id":"pp-wXTTv2-2","elementReferenceTagType":{},"type":"BillingAddressComponent"}];
+          var localizedStrings = {};
+          var widgetCreationEpochMilliseconds = 1749654319804;
+
+          wf.create('ViewPaymentPlanSummary', options, data, localizedStrings, widgetCreationEpochMilliseconds);
+        });
+      }());
+//]]></script>
+
+        </td>
+    </tr>
+</table>
+
+
+<div class="orderSummary">
+
+<br>
+
+
+    <table class="narrowed" align="center" border="0" cellpadding="0" cellspacing="0" width="90%">
+    <tr>
+      <td align="left" bgcolor="#ddddcc" border="0" cellpadding="0" cellspacing="0" valign="top" width="10" >
+        <img src="https://m.media-amazon.com/images/G/15/x-locale/common/tan-top-left-round-corner._CB485934687_.gif" width="10" alt="" height="28" border="0" />
+      </td>
+      <td bgcolor="#ddddcc" align="left" border="0" cellpadding="0" cellspacing="0">
+          <span class="section-header">Refunds
+</span>
+      </td>
+    </tr>
+  </table>
+  <table class="sample narrowed" align="center" cellpadding="10" cellspacing="0" width="90%">
+
+    <tr>
+      <td valign="top">
+            <strong>Refund date: Sept. 21 2024</strong>
+      </td>
+      <td align="right" valign="top">
+             Refund Amount: $14.99
+      </td>
+    </tr>
+
+   <table>
+
+</div>
+
+<br>
+
+
+
+
+
+
+
+</div>
+
+<script>window.P && P.register('sp.load.js');</script>
+    
+<!--&&&Portal&Delimiter&&&--><!-- sp:end-feature:host-atf -->
+<!-- sp:feature:nav-btf -->
+<!-- NAVYAAN BTF START -->
+
+
+
+
+
+
+  <script type='text/javascript'>(function ($Nav) {
+"use strict";
+
+if (typeof $Nav === 'undefined' || $Nav === null || typeof $Nav.when !== 'function') {
+    return;
+}
+
+$Nav.when('$', 'data', 'flyout.yourAccount', 'sidepanel.csYourAccount',
+          'config')
+    .run("BuyitAgain-YourAccount-SidePanel",
+    function ($, data, yaFlyout, csYourAccount, config) {
+        if (config.disableBuyItAgain) {
+            return;
+        }
+        var render = function (data) {
+            if (data.dramResult) {
+                var widgetHtml = data.dramResult;
+                navbar.sidePanel({
+                    flyoutName: 'yourAccount',
+                    data: {html: widgetHtml}
+                });
+            }
+        };
+
+        var renderBuyItAgain = function (biaData) {
+            if (csYourAccount) {
+                csYourAccount.register(render, biaData);
+            } else {
+                render(biaData);
+            }
+        };
+
+        var truncateAndRestructureYaFlyout = function() {
+            if (window.P) {
+                P.when('A', 'a-truncate').execute(function(A, truncate) {
+                    var truncateElements = A.$('.a-truncate');
+                    A.each(truncateElements, function(element) {
+                        truncate.get(element).update();
+                    });
+                    var recommendationsWidget = document.getElementById('bia-hcb-widget');
+                    if (recommendationsWidget) { 
+                        var navFlyout = recommendationsWidget.parentElement;
+                        var navFlyoutPaddingBottom = parseInt(window.getComputedStyle(navFlyout).getPropertyValue('padding-bottom'));
+                        var navFlyoutContentHeight = navFlyout.clientHeight - navFlyoutPaddingBottom;
+                        while (recommendationsWidget.offsetHeight > navFlyoutContentHeight && recommendationsWidget.offsetHeight > 0){
+                            var recommendations = recommendationsWidget.querySelectorAll('.biaNavFlyoutFaceout');
+                            if (recommendations.length <= 1) {
+                                break;
+                            }
+                            var lastRecommendation = recommendations[recommendations.length - 1];
+                            lastRecommendation.parentElement.removeChild(lastRecommendation);
+                        }
+                    }
+               });
+            }
+        };
+
+        yaFlyout.sidePanel.onData(truncateAndRestructureYaFlyout);
+        yaFlyout.onShow(truncateAndRestructureYaFlyout);
+
+    yaFlyout.onRender(function() {
+            $.ajax({
+                url: '/gp/bia/external/bia-hcb-ajax-handler.html',
+                data: {"biaHcbRid":"D32ZY1PB3E90Y6D0E1G7"},
+                dataType: 'json',
+                timeout: 4*1000,
+                success: renderBuyItAgain,
+                error: function (jqXHR, textStatus, errorThrown) {
+                }
+            });
+        });
+    });
+})(window.$Nav);</script>
+
+
+<script type="text/javascript">
+  window.$Nav && $Nav.when("data").run(function (data) {
+    data({
+      "accountListContent": { "html": "<div id='nav-al-container'><div id='nav-al-profile' class='nav-flyout-content nav-flyout-accessibility'></div><div id='nav-al-wishlist' class='nav-al-column nav-tpl-itemList nav-flyout-content nav-flyout-accessibility'><div class='nav-title' id='nav-al-title' role='heading' aria-level='6'>Your Lists</div><ul><li><a href='/hz/wishlist/ls?triggerElementID=createList&ref_=nav_ListFlyout_navFlyout_createList_lv_redirect' class='nav-link nav-item'><span class='nav-text'>Create a Wish List</span></a></li><li><a href='/wishlist/universal?ref_=nav_ListFlyout_gno_listpop_uwl' class='nav-link nav-item'><span class='nav-text'>Wish from Any Website</span></a></li><li><a href='/gcx/-/gfhz/?_encoding=UTF8&ref_=nav_wishlist_gf' class='nav-link nav-item'><span class='nav-text'>Find a Gift</span></a></li><li><a href='/baby-reg/homepage?ref_=nav_ListFlyout_gno_listpop_br' class='nav-link nav-item'><span class='nav-text'>Baby Registry</span></a></li><li><a href='/wedding/home?ref_=nav_ListFlyout_wr' class='nav-link nav-item'><span class='nav-text'>Wedding Registry</span></a></li><li><a href='/discover' class='nav-link nav-item'><span class='nav-text'>Discover Your Style</span></a></li><li><a href='/showroom?ref_=nav_ListFlyout_srm_your_desk_wl_ca' class='nav-link nav-item'><span class='nav-text'>Explore Showroom</span></a></li></ul></div><div id='nav-al-your-account' class='nav-al-column nav-template nav-flyout-content nav-tpl-itemList nav-flyout-accessibility'><div class='nav-title' role='heading' aria-level='6'>Your Account</div><ul><li><a id='nav-item-switch-account' href='https://www.amazon.ca/ap/signin?openid.pape.max_auth_age=0&openid.return_to=https%3A%2F%2Fwww.amazon.ca%2Fgp%2Fyourstore%2Fhome%2F%3Fie%3DUTF8%26orderID%3DD01-9262519-8073835%26ref_%3Dnav_youraccount_switchacct&openid.identity=http%3A%2F%2Fspecs.openid.net%2Fauth%2F2.0%2Fidentifier_select&openid.assoc_handle=caflex&openid.mode=checkid_setup&openid.claimed_id=http%3A%2F%2Fspecs.openid.net%2Fauth%2F2.0%2Fidentifier_select&openid.ns=http%3A%2F%2Fspecs.openid.net%2Fauth%2F2.0&switch_account=picker&ignoreAuthState=1&_encoding=UTF8' class='nav-link nav-item'><span class='nav-text'>Switch Accounts</span></a></li><li><a id='nav-item-signout' href='/gp/flex/sign-out.html?path=%2Fgp%2Fyourstore%2Fhome&signIn=1&useRedirectOnSuccess=1&action=sign-out&ref_=nav_AccountFlyout_signout' class='nav-link nav-item'><span class='nav-text'>Sign Out</span></a></li><div class='nav-divider'></div><li><a href='/gp/css/homepage.html?ref_=nav_AccountFlyout_ya' class='nav-link nav-item'><span class='nav-text'>Your Account</span></a></li><li><a id='nav_prefetch_yourorders' href='/gp/css/order-history?ref_=nav_AccountFlyout_orders' class='nav-link nav-item'><span class='nav-text'>Your Orders</span></a></li><li><a href='/hz/mobile/mission?ref_=nav_AccountFlyout_ci_mcx_mi_d_nf' class='nav-link nav-item'><span class='nav-text'>Keep shopping for</span></a></li><li><a href='/gp/yourstore?ref_=nav_AccountFlyout_recs' class='nav-link nav-item'><span class='nav-text'>Your Recommendations</span></a></li><li><a href='https://www.amazon.ca/your-product-safety-alerts?ref_=nav_AccountFlyout_flyout_bsx_ypsa' class='nav-link nav-item'><span class='nav-text'>Recalls and Product Safety Alerts</span></a></li><li><a href='/auto-deliveries?ref_=nav_AccountFlyout_sns' class='nav-link nav-item'><span class='nav-text'>Your Subscribe & Save Items</span></a></li><li><a href='/gp/primecentral?ref_=nav_AccountFlyout_prime' class='nav-link nav-item'><span class='nav-text'>Your Prime Membership</span></a></li><li><a href='/hz5/yourmembershipsandsubscriptions?ref_=nav_AccountFlyout_digital_subscriptions' class='nav-link nav-item'><span class='nav-text'>Memberships & Subscriptions</span></a></li><li><a href='/dp/B07MJM4F44?plattr=CACBCCNAVACC&ref_=nav_cbcc_ca_account' class='nav-link nav-item'><span class='nav-text'>Your Amazon Credit Card</span></a></li><li><a href='/hz/mycd/myx?pageType=content&ref_=nav_AccountFlyout_myk' class='nav-link nav-item'><span class='nav-text'>Content Library</span></a></li><li><a href='https://www.amazon.ca/hz/mycd/digital-console/alldevices?pageType=devices&ref_=nav_accountFlyOut_manage_devices' class='nav-link nav-item'><span class='nav-text'>Devices</span></a></li><li><a href='https://music.amazon.ca?ref=nav_youraccount_cldplyr' class='nav-link nav-item'><span class='nav-text'>Your Music Library</span></a></li><li><a href='/gp/video/ssoredirect?pvp=/ref%3Dnav_youraccount_apv&ref_=nav_AccountFlyout__apv' class='nav-link nav-item'><span class='nav-text'>Your Prime Video</span></a></li><li><a href='/photos?ref_=nav_AccountFlyout_photos' class='nav-link nav-item'><span class='nav-text'>Your Amazon Photos</span></a></li><li><a href='/gp/mas/your-account/myapps?ref_=nav_AccountFlyout_aad' class='nav-link nav-item'><span class='nav-text'>Your Apps & Devices</span></a></li><li><a href='/business/register/org/landing?ref_=nav_AccountFlyout_b2b_reg_bottom_create' class='nav-link nav-item'><span class='nav-text'>Create your free business account</span></a></li></ul></div></div>" },
+      "tooltipContent": { "html": "" },
+      "signinContent": { "html": "<div id='nav-signin-tooltip'><a href='https://www.amazon.ca/ap/signin?openid.pape.max_auth_age=0&openid.return_to=https%3A%2F%2Fwww.amazon.ca%2Fgp%2Fdigital%2Fyour-account%2Forder-summary.html%2Fref%3Dppx_hzod_rd_dt_b_digital_rd%2F%3Fie%3DUTF8%26orderID%3DD01-9262519-8073835%26ref_%3Dnav_custrec_signin&openid.identity=http%3A%2F%2Fspecs.openid.net%2Fauth%2F2.0%2Fidentifier_select&openid.assoc_handle=caflex&openid.mode=checkid_setup&openid.claimed_id=http%3A%2F%2Fspecs.openid.net%2Fauth%2F2.0%2Fidentifier_select&openid.ns=http%3A%2F%2Fspecs.openid.net%2Fauth%2F2.0' class='nav-action-signin-button' data-nav-role='signin' data-nav-ref='nav_custrec_signin'><span class='nav-action-inner'>Sign in</span></a><div class='nav-signin-tooltip-footer'>New customer? <a href='https://www.amazon.ca/ap/register?openid.pape.max_auth_age=0&openid.return_to=https%3A%2F%2Fwww.amazon.ca%2Fgp%2Fdigital%2Fyour-account%2Forder-summary.html%2Fref%3Dppx_hzod_rd_dt_b_digital_rd%2F%3Fie%3DUTF8%26orderID%3DD01-9262519-8073835%26ref_%3Dnav_custrec_newcust&openid.identity=http%3A%2F%2Fspecs.openid.net%2Fauth%2F2.0%2Fidentifier_select&openid.assoc_handle=caflex&openid.mode=checkid_setup&openid.claimed_id=http%3A%2F%2Fspecs.openid.net%2Fauth%2F2.0%2Fidentifier_select&openid.ns=http%3A%2F%2Fspecs.openid.net%2Fauth%2F2.0' class='nav-a' aria-label='New to Amazon? Start here to create an account'>Start here.</a></div></div>" },
+      "templates": {"itemList":"<# var hasColumns = (function () {  var checkColumns = function (_items) {    if (!_items) {      return false;    }    for (var i=0; i<_items.length; i++) {      if (_items[i].columnBreak || (_items[i].items && checkColumns(_items[i].items))) {        return true;      }    }    return false;  };  return checkColumns(items);}()); #><# if(hasColumns) { #>  <# if(items[0].image && items[0].image.src) { #>    <div class='nav-column nav-column-first nav-column-image'>  <# } else if (items[0].greeting) { #>    <div class='nav-column nav-column-first nav-column-greeting'>  <# } else { #>    <div class='nav-column nav-column-first'>  <# } #><# } #><# var renderItems = function(items) { #>  <# jQuery.each(items, function (i, item) { #>    <# if(hasColumns && item.columnBreak) { #>      <# if(item.image && item.image.src) { #>        </div><div class='nav-column nav-column-notfirst nav-column-break nav-column-image'>      <# } else if (item.greeting) { #>        </div><div class='nav-column nav-column-notfirst nav-column-break nav-column-greeting'>      <# } else { #>        </div><div class='nav-column nav-column-notfirst nav-column-break'>      <# } #>    <# } #>    <# if(item.dividerBefore) { #>      <div class='nav-divider'></div>    <# } #>    <# if(item.text || item.content) { #>      <# if(item.url) { #>        <a href='<#=item.url #>' class='nav-link      <# } else {#>        <span class='      <# } #>      <# if(item.panelKey) { #>        nav-hasPanel      <# } #>      <# if(item.items) { #>        nav-title      <# } #>      <# if(item.decorate == 'carat') { #>        nav-carat      <# } #>      <# if(item.decorate == 'nav-action-button') { #>        nav-action-button      <# } #>      nav-item'      <# if(item.extra) { #>        <#=item.extra #>      <# } #>      <# if(item.id) { #>        id='<#=item.id #>'      <# } #>      <# if(item.dataNavRole) { #>        data-nav-role='<#=item.dataNavRole #>'      <# } #>      <# if(item.dataNavRef) { #>        data-nav-ref='<#=item.dataNavRef #>'      <# } #>      <# if(item.panelKey) { #>        data-nav-panelkey='<#=item.panelKey #>'        role='navigation'        aria-label='<#=item.text#>'      <# } #>      <# if(item.subtextKey) { #>        data-nav-subtextkey='<#=item.subtextKey #>'      <# } #>      <# if(item.image && item.image.height > 16) { #>        style='line-height:<#=item.image.height #>px;'      <# } #>      >      <# if(item.decorate == 'carat') { #>        <i class='nav-icon'></i>      <# } #>      <# if(item.image && item.image.src) { #>        <img class='nav-image' src='<#=item.image.src #>' style='height:<#=item.image.height #>px; width:<#=item.image.width #>px;' />      <# } #>      <# if(item.text) { #>        <span class='nav-text<# if(item.classname) { #> <#=item.classname #><# } #>'><#=item.text#><# if(item.badgeText) { #>          <span class='nav-badge'><#=item.badgeText#></span>        <# } #></span>      <# } else if (item.content) { #>        <span class='nav-content'><# jQuery.each(item.content, function (j, cItem) { #><# if(cItem.url && cItem.text) { #><a href='<#=cItem.url #>' class='nav-a'><#=cItem.text #></a><# } else if (cItem.text) { #><#=cItem.text#><# } #><# }); #></span>      <# } #>      <# if(item.subtext) { #>        <span class='nav-subtext'><#=item.subtext #></span>      <# } #>      <# if(item.url) { #>        </a>      <# } else {#>        </span>      <# } #>    <# } #>    <# if(item.image && item.image.src) { #>      <# if(item.url) { #>        <a href='<#=item.url #>'>       <# } #>      <img class='nav-image'      <# if(item.id) { #>        id='<#=item.id #>'      <# } #>      src='<#=item.image.src #>' <# if (item.alt) { #> alt='<#= item.alt #>'<# } #>/>      <# if(item.url) { #>        </a>       <# } #>    <# } #>    <# if(item.items) { #>      <div class='nav-panel'> <# renderItems(item.items); #> </div>    <# } #>  <# }); #><# }; #><# renderItems(items); #><# if(hasColumns) { #>  </div><# } #>","subnav":"<# if (obj && obj.type === 'vertical') { #>  <# jQuery.each(obj.rows, function (i, row) { #>    <# if (row.flyoutElement === 'button') { #>      <div class='nav_sv_fo_v_button'        <# if (row.elementStyle) { #>          style='<#= row.elementStyle #>'        <# } #>      >        <a href='<#=row.url #>' class='nav-action-button nav-sprite'>          <#=row.text #>        </a>      </div>    <# } else if (row.flyoutElement === 'list' && row.list) { #>      <# jQuery.each(row.list, function (j, list) { #>        <div class='nav_sv_fo_v_column <#=(j === 0) ? 'nav_sv_fo_v_first' : '' #>'>          <ul class='<#=list.elementClass #>'>          <# jQuery.each(list.linkList, function (k, link) { #>            <# if (k === 0) { link.elementClass += ' nav_sv_fo_v_first'; } #>            <li class='<#=link.elementClass #>'>              <# if (link.url) { #>                <a href='<#=link.url #>' class='nav_a'><#=link.text #></a>              <# } else { #>                <span class='nav_sv_fo_v_span'><#=link.text #></span>              <# } #>            </li>          <# }); #>          </ul>        </div>      <# }); #>    <# } else if (row.flyoutElement === 'link') { #>      <# if (row.topSpacer) { #>        <div class='nav_sv_fo_v_clear'></div>      <# } #>      <div class='<#=row.elementClass #>'>        <a href='<#=row.url #>' class='nav_sv_fo_v_lmargin nav_a'>          <#=row.text #>        </a>      </div>    <# } #>  <# }); #><# } else if (obj) { #>  <div class='nav_sv_fo_scheduled'>    <#= obj #>  </div><# } #>","htmlList":"<# jQuery.each(items, function (i, item) { #>  <div class='nav-item'>    <#=item #>  </div><# }); #>"}
+    })
+  })
+</script>
+
+<script type="text/javascript">
+  window.$Nav && $Nav.declare('config.flyoutURL', null);
+  window.$Nav && $Nav.declare('btf.lite');
+  window.$Nav && $Nav.declare('btf.full');
+  window.$Nav && $Nav.declare('btf.exists');
+  (window.AmazonUIPageJS ? AmazonUIPageJS : P).register('navCF');
+</script>
+
+<!-- NAVYAAN BTF END -->
+<!-- sp:end-feature:nav-btf -->
+<!-- sp:feature:host-btf -->
+
+    
+<!-- sp:end-feature:host-btf -->
+<!-- sp:feature:aui-preload -->
+<!-- sp:end-feature:aui-preload -->
+<!-- sp:feature:nav-footer -->
+
+  <!-- NAVYAAN FOOTER START -->
+  <!-- WITH MOZART -->
+
+<div id='rhf' class='copilot-secure-display' style='clear: both;' role='complementary' aria-label='Your recently viewed items and featured recommendations'> <div class='rhf-frame' style='display: none;'> <br> <div id='rhf-container'> <div class='rhf-loading-outer'> <table class='rhf-loading-middle'> <tr> <td class='rhf-loading-inner'> <img src='https://m.media-amazon.com/images/G/15/personalization/ybh/loading-4x-gray._CB485916907_.gif'> </td> </tr> </table> </div> <div id='rhf-context'> <script type='application/json'> { "rhfHandlerParams":{"currentPageType":"AmazonFamilyDigitalOrderApplication","currentSubPageType":"","excludeAsin":"","fieldKeywords":"","k":"","keywords":"","search":"","auditEnabled":"","previewCampaigns":"","forceWidgets":"","searchAlias":""} } </script> </div> </div> <noscript> <div class='rhf-border'> <div class='rhf-header'> Your recently viewed items and featured recommendations </div> <div class='rhf-footer'> <div class='rvi-container'> <div class='ybh-edit'> <div class='ybh-edit-arrow'> &#8250; </div> <div class='ybh-edit-link'> <a href='/gp/history'> View or edit your browsing history </a> </div> </div> <span class='no-rvi-message'> After viewing product detail pages, look here to find an easy way to navigate back to pages that interest you. </span> </div> </div> </div> </noscript> <div id='rhf-error' style='display: none;'> <div class='rhf-border'> <div class='rhf-header'> Your recently viewed items and featured recommendations </div> <div class='rhf-footer'> <div class='rvi-container'> <div class='ybh-edit'> <div class='ybh-edit-arrow'> &#8250; </div> <div class='ybh-edit-link'> <a href='/gp/history'> View or edit your browsing history </a> </div> </div> <span class='no-rvi-message'> After viewing product detail pages, look here to find an easy way to navigate back to pages that interest you. </span> </div> </div> </div> </div> <br> </div> </div>
+<div class="navLeftFooter nav-sprite-v1" id="navFooter">
+  
+<a id="navBackToTop" aria-label="Back to top" role="button">
+  <div class="navFooterBackToTop">
+  <span class="navFooterBackToTopText">
+    Back to top
+  </span>
+  </div>
+</a>
+
+  
+<div class="navFooterVerticalColumn navAccessibility" role="presentation">
+  <div class="navFooterVerticalRow navAccessibility">
+        <div class="navFooterLinkCol navAccessibility">
+          <div class="navFooterColHead" role="heading" aria-level="6">Get to Know Us</div>
+        <ul>
+            <li class="nav_first">
+              <a href="https://www.amazon.jobs" class="nav_a">Careers</a>
+            </li>
+            <li >
+              <a href="/gp/help/customer/display.html?nodeId=200700220&ref_=footer_corpres" class="nav_a">Amazon and Our Planet</a>
+            </li>
+            <li >
+              <a href="/gp/help/customer/display.html?nodeId=GXYZF9M33FRJ5TMA" class="nav_a">Modern Slavery Statement</a>
+            </li>
+            <li >
+              <a href="https://www.amazon.ca/ir" class="nav_a">Investor Relations</a>
+            </li>
+            <li >
+              <a href="https://www.amazon.ca/pr" class="nav_a">Press Releases</a>
+            </li>
+            <li class="nav_last ">
+              <a href="https://www.amazon.science" class="nav_a">Amazon Science</a>
+            </li>
+        </ul>
+      </div>
+        <div class="navFooterColSpacerInner navAccessibility"></div>
+        <div class="navFooterLinkCol navAccessibility">
+          <div class="navFooterColHead" role="heading" aria-level="6">Make Money with Us</div>
+        <ul>
+            <li class="nav_first">
+              <a href="https://sell.amazon.ca/en?ld=AZFSSOA-CA-footer&ref_=footer_soa" class="nav_a">Sell on Amazon</a>
+            </li>
+            <li >
+              <a href="https://supply.amazon.ca?ref_=footer_sta&lang=en-CA" class="nav_a">Supply to Amazon</a>
+            </li>
+            <li >
+              <a href="https://associates.amazon.ca" class="nav_a">Become an Affiliate</a>
+            </li>
+            <li >
+              <a href="https://brandservices.amazon.ca/?ref=AOCAABRLGNRFOOT&ld=AOCAABRLGNRFOOT" class="nav_a">Protect & Build Your Brand</a>
+            </li>
+            <li >
+              <a href="https://sell.amazon.ca/en/programs/handmade/?ld=AZCAHND-footer&ref_=footer_sell" class="nav_a">Sell on Amazon Handmade</a>
+            </li>
+            <li >
+              <a href="https://advertising.amazon.ca/?ref=footer_advtsing_amzn_ca" class="nav_a">Advertise Your Products</a>
+            </li>
+            <li >
+              <a href="https://kdp.amazon.com?language=en_US" class="nav_a">Independently Publish with Us</a>
+            </li>
+            <li class="nav_last ">
+              <a href="https://www.amazon.ca/b?ie=UTF8&node=15576834011" class="nav_a">Host an Amazon Hub</a>
+            </li>
+        </ul>
+      </div>
+        <div class="navFooterColSpacerInner navAccessibility"></div>
+        <div class="navFooterLinkCol navAccessibility">
+          <div class="navFooterColHead" role="heading" aria-level="6">Amazon Payment Products</div>
+        <ul>
+            <li class="nav_first">
+              <a href="/dp/B07MJM4F44?plattr=CACBCCFOOT&ref_=nav_cbcc_ca_footer" class="nav_a">Amazon.ca Rewards Mastercard</a>
+            </li>
+            <li >
+              <a href="/gp/browse.html?node=21371066011&ref_=footer_swp" class="nav_a">Shop with Points</a>
+            </li>
+            <li >
+              <a href="/gp/gc/create?ref_=footer_reload_ca" class="nav_a">Reload Your Balance</a>
+            </li>
+            <li >
+              <a href="/gp/browse.html?node=8438004011&ref_=footer_tfx_ca_en" class="nav_a">Amazon Currency Converter</a>
+            </li>
+            <li >
+              <a href="/gp/browse.html?node=9230166011&ref_=footer_gift_cards_ca_en" class="nav_a">Gift Cards</a>
+            </li>
+            <li class="nav_last ">
+              <a href="/gp/browse.html?node=17321486011&ref_=footer_cash_ca_en" class="nav_a">Amazon Cash</a>
+            </li>
+        </ul>
+      </div>
+        <div class="navFooterColSpacerInner navAccessibility"></div>
+        <div class="navFooterLinkCol navAccessibility">
+          <div class="navFooterColHead" role="heading" aria-level="6">Let Us Help You</div>
+        <ul>
+            <li class="nav_first">
+              <a href="/gp/help/customer/display.html?nodeId=915470&ref_=footer_shiprates" class="nav_a">Shipping Rates & Policies</a>
+            </li>
+            <li >
+              <a href="/gp/prime?ref_=footer_prime" class="nav_a">Amazon Prime</a>
+            </li>
+            <li >
+              <a href="/gp/css/returns/homepage.html?ref_=footer_hy_f_4" class="nav_a">Returns Are Easy</a>
+            </li>
+            <li >
+              <a href="/hz/mycd/myx?ref_=footer_myk" class="nav_a">Manage your Content and Devices</a>
+            </li>
+            <li >
+              <a href="https://www.amazon.ca/product-safety-alerts?ref_=footer_bsx_ypsa" class="nav_a">Recalls and Product Safety Alerts</a>
+            </li>
+            <li >
+              <a href="/registries?ref_=nav_footer_registry_giftlist_desktop" class="nav_a">Registry & Gift List</a>
+            </li>
+            <li class="nav_last ">
+              <a href="/gp/help/customer/display.html?nodeId=508510&ref_=footer_gw_m_b_he" class="nav_a">Customer Service</a>
+            </li>
+        </ul>
+      </div>
+  </div>
+</div>
+<div class="nav-footer-line"></div>
+
+  <div class="navFooterLine navFooterLinkLine navFooterPadItemLine">
+    <span>
+      <div class="navFooterLine navFooterLogoLine">
+        <a  aria-label="Amazon Canada Home"   lang="en"  href="/?ref_=footer_logo">
+        <div class="nav-logo-base nav-sprite"></div>
+        </a>
+      </div>
+</span>
+    
+      <span class="icp-container-desktop"><div
+          class="navFooterLine">
+<style type="text/css">
+  #icp-touch-link-language { display: none; }
+</style>
+
+
+<div class="icp-button" id="icp-touch-link-language" >
+<a href="/customer-preferences/edit?ie=UTF8&preferencesReturnUrl=%2F&ref_=footer_lang" class="icp-language-link" aria-label="Choose a language for shopping. Current selection is English. ">
+  <div class="icp-nav-globe-img-2 icp-button-globe-2"></div><span class="icp-color-base">English</span>
+</a>
+<button class="nav-arrow icp-up-down-arrow" aria-controls="nav-flyout-icp-footer-flyout" aria-label="Expand to Change Language or Country"></button>
+</div>
+
+<style type="text/css">
+#icp-touch-link-country { display: none; }
+</style>
+<a href="/customer-preferences/country?ie=UTF8&preferencesReturnUrl=%2F&ref_=footer_icp_cp" role="button" aria-label="Choose a country/region for shopping. The current selection is Canada." class="icp-button" id="icp-touch-link-country">
+  <span class="icp-flag-3 icp-flag-3-ca"></span><span class="icp-color-base">Canada</span>
+</a>
+</div></span>
+    
+  </div>
+  
+  
+  <div class="navFooterLine navFooterLinkLine navFooterDescLine"  aria-label="More on Amazon">
+    <div class="navFooterMoreOnAmazon navFooterMoreOnAmazonWrapper" aria-label="More on Amazon">
+      <ul>
+<li class="navFooterDescItem"><a href=https://music.amazon.ca?ref=dm_aff_amz_ca class="nav_a"><h5 class="navFooterDescItem_heading">Amazon Music</h5><span class="navFooterDescText">Stream millions<br>of songs</span></a></li><li class="navFooterDescSpacer" aria-hidden="true" style="width: 4%"></li>
+<li class="navFooterDescItem"><a href=https://advertising.amazon.ca/?ref=footer_advtsing_amzn_ca class="nav_a"><h5 class="navFooterDescItem_heading">Amazon Advertising </h5><span class="navFooterDescText"> Find, attract and engage customers</span></a></li><li class="navFooterDescSpacer" aria-hidden="true" style="width: 4%"></li>
+<li class="navFooterDescItem"><a href=/business?ref_=footer_retail_b2b class="nav_a"><h5 class="navFooterDescItem_heading">Amazon Business</h5><span class="navFooterDescText">Everything for<br>your business</span></a></li><li class="navFooterDescSpacer" aria-hidden="true" style="width: 4%"></li>
+<li class="navFooterDescItem"><a href=https://www.abebooks.com class="nav_a"><h5 class="navFooterDescItem_heading">AbeBooks</h5><span class="navFooterDescText">Books, art<br>& collectables</span></a></li><li class="navFooterDescSpacer" aria-hidden="true" style="width: 4%"></li>
+<li class="navFooterDescItem"><a href=/gp/browse.html?node=16055945011&ref_=_ca_footer_drive class="nav_a"><h5 class="navFooterDescItem_heading">Amazon Drive</h5><span class="navFooterDescText">Cloud storage<br>from Amazon</span></a></li></ul>
+
+<ul>
+<li class="navFooterDescItem"><a href=https://aws.amazon.com/what-is-cloud-computing/?sc_channel=EL&sc_campaign=CA_amazonfooter class="nav_a"><h5 class="navFooterDescItem_heading">Amazon Web Services</h5><span class="navFooterDescText">Scalable Cloud<br>Computing Services</span></a></li><li class="navFooterDescSpacer" aria-hidden="true" style="width: 4%"></li>
+<li class="navFooterDescItem"><a href=https://www.goodreads.com/ class="nav_a"><h5 class="navFooterDescItem_heading">Goodreads</h5><span class="navFooterDescText">Book reviews<br>& recommendations</span></a></li><li class="navFooterDescSpacer" aria-hidden="true" style="width: 4%"></li>
+<li class="navFooterDescItem"><a href=https://www.imdb.com/ class="nav_a"><h5 class="navFooterDescItem_heading">IMDb</h5><span class="navFooterDescText">Movies, TV<br>& Celebrities</span></a></li><li class="navFooterDescSpacer" aria-hidden="true" style="width: 4%"></li>
+<li class="navFooterDescItem"><a href=/gp/browse.html?node=16055944011&ref_=_gno_p_foot class="nav_a"><h5 class="navFooterDescItem_heading">Amazon Photos</h5><span class="navFooterDescText">Unlimited Photo Storage<br>Free With Prime</span></a></li><li class="navFooterDescSpacer" aria-hidden="true" style="width: 4%"></li>
+<li class="navFooterDescItem"><a href=https://www.shopbop.com/ class="nav_a"><h5 class="navFooterDescItem_heading">Shopbop</h5><span class="navFooterDescText">Designer<br>Fashion Brands</span></a></li></ul>
+
+<ul>
+<li class="navFooterDescItem"><a href=/gp/browse.html?node=8929975011&ref_=footer_warehouse_deals class="nav_a"><h5 class="navFooterDescItem_heading">Amazon Resale</h5><span class="navFooterDescText">Great Deals on<br>Quality Used Products </span></a></li><li class="navFooterDescSpacer" aria-hidden="true" style="width: 4%"></li>
+<li class="navFooterDescItem"><a href=https://www.wholefoodsmarket.com class="nav_a"><h5 class="navFooterDescItem_heading">Whole Foods Market</h5><span class="navFooterDescText">We Believe in<br>Real Food</span></a></li><li class="navFooterDescSpacer" aria-hidden="true" style="width: 4%"></li>
+<li class="navFooterDescItem"><a href=/gp/browse.html?node=17351028011&ref_=footer_carenew class="nav_a"><h5 class="navFooterDescItem_heading">Amazon Renewed</h5><span class="navFooterDescText">Like-new products<br>you can trust</span></a></li><li class="navFooterDescSpacer" aria-hidden="true" style="width: 4%"></li>
+<li class="navFooterDescItem"><a href=https://blinkforhome.com/?ref=nav_footer_ca class="nav_a"><h5 class="navFooterDescItem_heading">Blink</h5><span class="navFooterDescText">Smart Security<br>for Every Home
+</span></a></li><li class="navFooterDescSpacer" aria-hidden="true" style="width: 4%"></li>
+<li class="navFooterDescItem" aria-hidden="true">&nbsp;</li>
+</ul>
+
+    </div>
+  </div>
+
+  
+<div class="navFooterLine navFooterLinkLine navFooterPadItemLine navFooterCopyright">
+  <ul><li class="nav_first"><a href="/gp/help/customer/display.html?nodeId=918816&ref_=footer_cou" id="" class="nav_a">Conditions of Use</a> </li><li ><a href="/gp/help/customer/display.html?nodeId=918814&ref_=footer_privacy" id="" class="nav_a">Privacy Notice</a> </li><li ><a href="/gp/help/customer/display.html?nodeId=GVASXV5UZ64R4Y25&ref_=footer_cookies_notice" id="" class="nav_a">Cookies Notice</a> </li><li class="nav_last"><a href="/gp/help/customer/display.html?nodeId=202146130&ref_=footer_iba" id="" class="nav_a">Interest-Based Ads</a> </li></ul><span>© 1996-2025, Amazon.com, Inc. or its affiliates</span>
+</div>
+<div class="navFooterLine navFooterLinkLine navFooterPadItemLine navFooterCopyright">
+  <ul><li class="nav_first nav_last">Amazon.com.ca ULC | 40 King Street W 47th Floor, Toronto, Ontario, Canada, M5H 3Y2 |1-877-586-3230</li></ul>
+</div>
+
+  
+</div>
+<div id="sis_pixel_r2" aria-hidden="true" style="height:1px; position: absolute; left: -1000000px; top: -1000000px;"></div><script>(function(a,b){a.attachEvent?a.attachEvent("onload",b):a.addEventListener&&a.addEventListener("load",b,!1)})(window,function(){setTimeout(function(){var el=document.getElementById("sis_pixel_r2");el&&(el.innerHTML='<iframe id="DAsis" src="//s.amazon-adsystem.com/iu3?d=amazon.ca&slot=navFooter&a1=Pa0QgDz9hwDQs-eMpIuyeKOrg&a2=010122b39061a7538547fb4acb5f6472b682e5642fc5b78b39e7327cb7b31b4b7eb8&old_oo=0&ts=1749654319892&s=AYoh5jMQ1D0ui4mnkR_7llEc5aLpgO16oxNTMBOaVaNu&gdpr_consent=&gdpr_consent_avl=&cb=1749654319892" width="1" height="1" frameborder="0" marginwidth="0" marginheight="0" scrolling="no" tabindex="-1" sandbox></iframe>');var event=new Event("SISPixelCardLoaded");document.dispatchEvent(event);},300)});</script>
+
+  <!-- NAVYAAN FOOTER END -->
+
+<!-- sp:end-feature:nav-footer -->
+<!-- sp:feature:configured-sitewide-assets -->
+<script>
+(window.AmazonUIPageJS ? AmazonUIPageJS : P).when('afterLoad').execute(function() {
+(function(c,C,w){var x=c.ue||{},r=function(){},k=function(c){return function(g,l){l||(l="ERROR");g=g&&g.stack&&g.message?g:JSON.stringify(g);c({logLevel:l,attribution:"MSAVowelsJavascriptAssets",message:g})}}(c.ueLogError||r),m=function(c){return function(g,l){c("MSAVowelsJavascriptAssets:"+g,l)}}(x.count||r),y=function(c){return function(){try{return c.apply(this,arguments)}catch(g){k(g,"FATAL")}}},t=function(){var k=Array.prototype.slice.call(arguments,0);k[0]=y(k[0]);return c.setTimeout.apply(null,
+k)},v=function(){m("invoked",1);var r=function(c,g){c={events:[{data:c}]};c=JSON.stringify(c);g="https://unagi-na.amazon.com/1/events/"+g;navigator&&navigator.sendBeacon?navigator.sendBeacon(g,c):fetch(g,{method:"POST",body:c}).catch(function(c){k(c,"WARN")})},g=function(c){r(c,"com.amazon.Vowels.ClientMetrics")};t(function(){function l(){for(var a=new URLSearchParams,b=0;b<arguments.length;b++){var d=arguments[b],h;for(h in d)a.set(h,d[h])}return a.toString()}function z(){for(var a={},b=0;b<arguments.length;b++){var d=
+arguments[b],h;for(h in d)a[h]=d[h]}return a}function v(){var a=/(https:\/\/www\.amazon\.[a-zA-Z]*(?:\.[a-zA-Z]*)?)/i;return D&&E&&a.test(D)?E:"Unknown"}function x(a){for(var b={pg_siz:0,m_siz:0,pg_esiz:0,m_esiz:0,ai_siz:0,ai_esiz:0},d=/^https:.*\.(?:(?:ssl-)?images|media)-amazon\.com\/images\//i,h=/^https:\/\/m\.media-amazon\.com\/images\/I\/.*\?aicid=/i,f=0;f<a.length;f++){var e=a[f];b.pg_siz+=e.transferSize;b.pg_esiz+=e.encodedBodySize;d.test(e.name)&&(b.m_siz+=e.transferSize,b.m_esiz+=e.encodedBodySize);
+h.test(e.name)&&(b.ai_siz+=e.transferSize,b.ai_esiz+=e.encodedBodySize)}return b}function y(a,b){if(a){var d={pg_siz:0,m_siz:0,pg_esiz:0,m_esiz:0,ai_siz:0,ai_esiz:0,fcp:0,lcp:0,pg_type:v(),dpr:c.devicePixelRatio||0,csm_markers:J(),cdn:b};b=n.getEntriesByType("paint");for(var h=0;h<b.length;h++)if("first-contentful-paint"===b[h].name){d.fcp=b[h].startTime;break}var f=x(a);if(c.PerformanceObserver){var e=new c.PerformanceObserver(function(b){b=b.getEntries();if(0!==b.length){var a=b[b.length-1];b.forEach(function(b){b.element&&
+"IMG"===b.element.tagName&&a.startTime<b.startTime&&(a=b)});d.lcp=a.startTime;e.disconnect()}});try{e.observe({type:"largest-contentful-paint",buffered:!0})}catch(P){}}t(function(){d.pg_siz=f.pg_siz;d.m_siz=f.m_siz;d.ai_siz=f.ai_siz;d.pg_esiz=f.pg_esiz;d.m_esiz=f.m_esiz;d.ai_esiz=f.ai_esiz;var b=z(A,d);r(b,"com.amazon.Vowels.PageWeightMetrics")},1E3)}}function J(){if(!c.ue||!c.ue.markers)return{};var a=c.ue.markers,b=a.tc,d={};Object.keys(a).forEach(function(h){var f=a[h];d[h]=f&&b?Math.max(0,f-b):
+w});return d}function F(a,b){var d=a.name,h=a.startTime||0,f=a.connectEnd||0,e=a.connectStart||0,c=a.domainLookupEnd||0,k=a.domainLookupStart||0,n=a.requestStart||0,l=a.responseEnd||0,m=a.responseStart||0,r=a.secureConnectionStart||0,t=a.transferSize||0,u=a.duration||0;0>=u&&0<h&&0<l&&(u=l-h);var p={src:d,sy:b+".2023-05-05"};0<=d.indexOf("/images/G/01/msa/vowels/metrics")?p.l=q(u):(0<t&&(p.siz=t),0<m-n&&0<m&&0<n&&(p.ttf=q(m-n)),0<l-m&&0<l&&0<m&&(p.con=q(l-m)),0<u&&(p.dur=q(u)));0<c-k&&0<c&&0<k&&(p.dns=
+q(c-k));0<f-e&&0<f&&0<e&&(p.tcp=q(f-e));0<f-r&&0<f&&0<r&&(p.tls=q(f-r));"serverTiming"in a&&a.serverTiming.slice(0,15).forEach(function(b){var a="st_"+b.name,d=b.description.substring(0,Math.min(64,b.description.length));p[a]=encodeURIComponent(b.duration+";"+d)});a=z(A,p);g(a)}function G(a){var b=z(A,{src:a,error:1}),d=n.now();return fetch(a).then(function(h){var f=n.now();var e=h.headers.get("x-cache")||"";e=0<=e.indexOf("cloudfront")?"c":0<=e.indexOf("akamai")?"a":0<=e.indexOf("fastly")?"f":"u";
+if(!h.ok)throw b.l=q(f-d),b.status=h.status,b.sy=e+".2023-05-05",H(e,b),b;h={name:a,duration:f-d};f=n.getEntriesByName(a);F(1===f.length?f[0]:h,e);return{cdn:e,url:a}},function(a){b.message=a.message;b.sy="u.2023-05-05";H("u",b);throw a;})}function H(a,b){try{var d=new URL(b.src)}catch(f){throw f;}var c=b.status;"u"===a?K(d,c).then(function(a){a.forEach(function(a){b.sy=a+".2023-05-05";g(b)})}):g(b)}function K(a,b){var d=[];a=[B(a,"f"),B(a,"c"),B(a,"a")];return c.Promise.all(a.map(L)).then(function(a){a.forEach(function(a){"fulfilled"===
+a.status?b&&a.value.statusCode===b&&d.push(a.value.cdn):b===w&&d.push(a.reason)});return 0<d.length?d:["u"]}).catch(function(a){k(a,"FATAL")})}function L(a){return a.then(function(a){return{value:a,status:"fulfilled"}},function(a){return{reason:a,status:"rejected"}})}function B(a,b){a.hostname=M[b];return fetch(a).then(function(a){return{cdn:b,statusCode:a.status}}).catch(function(a){k(a,"WARN");throw b;})}function N(a){for(var b=new RegExp("^https://(.*.(images|ssl-images|media)-amazon.com|"+c.location.hostname+
+")/images/","i"),d={},h=0,f="",e,g,k=a.length-1;0<=k;k--)e=a[k],0<e.transferSize&&e.transferSize>=e.encodedBodySize&&(e=b.exec(String(a[k].name)))&&3===e.length&&(e=e[1],g=d[e]=(d[e]||0)+1,g>h&&(f=e,h=g));return f}var I=navigator.userAgent,q=Math.round,n=c.performance,D=c.location.origin,E=c.ue_pty,A={s:C.domain,u:c.location.pathname,tz:I},M={a:"a.media-amazon.com",c:"dk9ps7goqoeef.cloudfront.net",f:"f.media-amazon.com"},O=c.URLSearchParams&&c.fetch&&c.Promise;n&&"function"===typeof n.getEntriesByName&&
+"function"===typeof n.getEntriesByType&&"function"===typeof n.now&&0>I.toLowerCase().indexOf("firefox")&&O?function(){var a=n.getEntriesByType("resource"),b=N(a)||"m.media-amazon.com";G("https://"+b+"/images/G/01/msa/vowels/metrics.jpg?"+l({time:+new Date,rand:q(1E6*Math.random()).toString()})).then(function(){var a="STID"+q(1E6*Math.random()).toString()+"-"+ +new Date;return G("https://"+b+"/images/G/01/msa/vowels/metrics._"+a+"_.jpg")}).then(function(d){d=d.cdn;m("cdn:"+d,1);if(a===w||0>=a.length)var c=
+0;else{c="https://"+b+"/images/";var f,e=0;for(f=0;f<a.length&&3>e;f++){var g=a[f];var k=g.name;0<g.transferSize&&g.transferSize>=g.encodedBodySize&&0===k.indexOf(c)&&!(0<k.indexOf("/images/G/01/msa/vowels/metrics"))&&(F(g,d),e++)}c=e}m("resourceCount",c);y(a,d)},function(a){m("resourceError",1);a instanceof TypeError&&a.message&&a.message.includes("Failed to fetch")?k(a,"WARN"):k(a,"ERROR")}).catch(function(a){k(a,"FATAL")})}():m("unsupportedBrowser",1)},4E3)};"loading"!==C.readyState?t(v,1E3):c.addEventListener&&
+c.addEventListener("DOMContentLoaded",function(){t(v,1E3)});m("registered",1)})(window,document);
+});
+</script>
+<script>
+(window.AmazonUIPageJS ? AmazonUIPageJS : P).when('afterLoad').execute(function() {
+  (window.AmazonUIPageJS ? AmazonUIPageJS : P).load.js('https://m.media-amazon.com/images/I/41nrkMYuv+L.js?AUIClients/AmazonLightsaberPageAssets#1221874-T1');
+});
+</script>
+<script>
+(window.AmazonUIPageJS ? AmazonUIPageJS : P).when('afterLoad').execute(function() {
+  (window.AmazonUIPageJS ? AmazonUIPageJS : P).load.js('https://m.media-amazon.com/images/I/11tKFQTcwoL.js?AUIClients/WebFlowIngressJs');
+});
+</script>
+<!-- sp:end-feature:configured-sitewide-assets -->
+<!-- sp:feature:customer-behavior-js -->
+<script type="text/javascript">if (window.ue && ue.tag) { ue.tag('FWCIMEnabled'); }</script>
+<script type="text/javascript">window.fwcimData = { customerId: 'A3QJNV48OOU9F8' };</script>
+<script>
+(window.AmazonUIPageJS ? AmazonUIPageJS : P).when('afterLoad').execute(function() {
+  (window.AmazonUIPageJS ? AmazonUIPageJS : P).load.js('https://m.media-amazon.com/images/I/71hE7IvdPvL.js?AUIClients/FWCIMAssets');
+});
+</script>
+<!-- sp:end-feature:customer-behavior-js -->
+<!-- sp:feature:csm:body-close -->
+<div id='be' style="display:none;visibility:hidden;"><form name='ue_backdetect' action="get"><input type="hidden" name='ue_back' value='1' /></form>
+
+
+<script type="text/javascript">
+window.ue_ibe = (window.ue_ibe || 0) + 1;
+if (window.ue_ibe === 1) {
+(function(e,c){function h(b,a){f.push([b,a])}function g(b,a){if(b){var c=e.head||e.getElementsByTagName("head")[0]||e.documentElement,d=e.createElement("script");d.async="async";d.src=b;d.setAttribute("crossorigin","anonymous");a&&a.onerror&&(d.onerror=a.onerror);a&&a.onload&&(d.onload=a.onload);c.insertBefore(d,c.firstChild)}}function k(){ue.uels=g;for(var b=0;b<f.length;b++){var a=f[b];g(a[0],a[1])}ue.deffered=1}var f=[];c.ue&&(ue.uels=h,c.ue.attach&&c.ue.attach("load",k))})(document,window);
+
+
+if (window.ue && window.ue.uels) {
+        var cel_widgets = [ { "c":"celwidget" },{ "s":"#nav-swmslot > div", "id_gen":function(elem, index){ return 'nav_sitewide_msg'; } } ];
+
+                ue.uels("https://images-na.ssl-images-amazon.com/images/I/216YVwoRFDL.js");
+}
+var ue_mbl=ue_csm.ue.exec(function(h,a){function s(c){b=c||{};a.AMZNPerformance=b;b.transition=b.transition||{};b.timing=b.timing||{};if(a.csa){var d;b.timing.transitionStart&&(d=b.timing.transitionStart);b.timing.processStart&&(d=b.timing.processStart);d&&(csa("PageTiming")("mark","nativeTransitionStart",d),csa("PageTiming")("mark","transitionStart",d))}h.ue.exec(t,"csm-android-check")()&&b.tags instanceof Array&&(c=-1!=b.tags.indexOf("usesAppStartTime")||b.transition.type?!b.transition.type&&-1<
+b.tags.indexOf("usesAppStartTime")?"warm-start":void 0:"view-transition",c&&(b.transition.type=c));n=null;"reload"===e._nt&&h.ue_orct||"intrapage-transition"===e._nt?u(b):"undefined"===typeof e._nt&&f&&f.timing&&f.timing.navigationStart&&a.history&&"function"===typeof a.History&&"object"===typeof a.history&&a.history.length&&1!=a.history.length&&(b.timing.transitionStart=f.timing.navigationStart);p&&e.ssw(q,""+(b.timing.transitionStart||n||""));c=b.transition;d=e._nt?e._nt:void 0;c.subType=d;a.ue&&
+a.ue.tag&&a.ue.tag("has-AMZNPerformance");e.isl&&a.uex&&a.uex("at","csm-timing");v()}function w(c){a.ue&&a.ue.count&&a.ue.count("csm-cordova-plugin-failed",1)}function t(){return a.cordova&&a.cordova.platformId&&"android"==a.cordova.platformId}function u(){if(p){var c=e.ssw(q),a=function(){},x=e.count||a,a=e.tag||a,k=b.timing.transitionStart,g=c&&!c.e&&c.val;n=c=g?+c.val:null;k&&g&&k>c?(x("csm.jumpStart.mtsDiff",k-c||0),a("csm-rld-mts-gt")):k&&g?a("csm-rld-mts-leq"):g?k||a("csm-rld-mts-no-new"):a("csm-rld-mts-no-old")}f&&
+f.timing&&f.timing.navigationStart?b.timing.transitionStart=f.timing.navigationStart:delete b.timing.transitionStart}function v(){try{a.P.register("AMZNPerformance",function(){return b})}catch(c){}}function r(){if(!b)return"";ue_mbl.cnt=null;var c=b.timing,d=b.transition,d=["mts",l(c.transitionStart),"mps",l(c.processStart),"mtt",d.type,"mtst",d.subType,"mtlt",d.launchType];a.ue&&a.ue.tag&&(c.fr_ovr&&a.ue.tag("fr_ovr"),c.fcp_ovr&&a.ue.tag("fcp_ovr"),d.push("fr_ovr",l(c.fr_ovr),"fcp_ovr",l(c.fcp_ovr)));
+for(var c="",e=0;e<d.length;e+=2){var f=d[e],g=d[e+1];"undefined"!==typeof g&&(c+="&"+f+"="+g)}return c}function l(a){if("undefined"!==typeof a&&"undefined"!==typeof m)return a-m}function y(a,d){b&&(m=d,b.timing.transitionStart=a,b.transition.type="view-transition",b.transition.subType="ajax-transition",b.transition.launchType="normal",ue_mbl.cnt=r)}var e=h.ue||{},m=h.ue_t0,q="csm-last-mts",p=1===h.ue_sswmts,n,f=a.performance,b;if(a.P&&a.P.when&&a.P.register)return 1===a.ue_fnt&&(m=a.aPageStart||
+h.ue_t0),a.P.when("CSMPlugin").execute(function(a){a.buildAMZNPerformance&&a.buildAMZNPerformance({successCallback:s,failCallback:w})}),{cnt:r,ajax:y}},"mobile-timing")(ue_csm,ue_csm.window);
+
+(function(d){d._uess=function(){var a="";screen&&screen.width&&screen.height&&(a+="&sw="+screen.width+"&sh="+screen.height);var b=function(a){var b=document.documentElement["client"+a];return"CSS1Compat"===document.compatMode&&b||document.body["client"+a]||b},c=b("Width"),b=b("Height");c&&b&&(a+="&vw="+c+"&vh="+b);return a}})(ue_csm);
+
+(function(a){function d(a){c&&c("log",a)}var b=document.ue_backdetect,c=a.csa&&a.csa("Errors",{producerId:"csa",logOptions:{ent:"all"}});a.ue_err.buffer&&c&&(a.ue_err.buffer.forEach(d),a.ue_err.buffer.push=d);b&&b.ue_back&&a.ue&&(a.ue.bfini=b.ue_back.value);a.uet&&a.uet("be");a.onLdEnd&&(window.addEventListener?window.addEventListener("load",a.onLdEnd,!1):window.attachEvent&&window.attachEvent("onload",a.onLdEnd));a.ueh&&a.ueh(0,window,"load",a.onLd,1);a.ue&&a.ue.tag&&(a.ue_furl?(b=a.ue_furl.replace(/\./g,
+"-"),a.ue.tag(b)):a.ue.tag("nofls"))})(ue_csm);
+
+(function(g,h){function d(a,d){var b={};if(!e||!f)try{var c=h.sessionStorage;c?a&&("undefined"!==typeof d?c.setItem(a,d):b.val=c.getItem(a)):f=1}catch(g){e=1}e&&(b.e=1);return b}var b=g.ue||{},a="",f,e,c,a=d("csmtid");f?a="NA":a.e?a="ET":(a=a.val,a||(a=b.oid||"NI",d("csmtid",a)),c=d(b.oid),c.e||(c.val=c.val||0,d(b.oid,c.val+1)),b.ssw=d);b.tabid=a})(ue_csm,ue_csm.window);
+
+(function(a){var e={rc:1,hob:1,hoe:1,ntd:1,rd_:1,_rd:1};"function"===typeof window.addEventListener&&window.addEventListener("pageshow",function(b){if(b&&b.persisted&&(b=+new Date,b={clickTime:b-1,pageVisible:b},"object"===typeof b&&"object"===typeof a.ue.markers&&"object"===typeof a.ue&&"function"===typeof a.uex)){if("function"===typeof a.uet){for(var c in a.ue.markers)!a.ue.markers.hasOwnProperty(c)||c in e||a.uet(c,void 0,void 0,b.pageVisible);a.uet("tc",void 0,void 0,b.clickTime);a.uet("ty",void 0,
+void 0,b.clickTime+2)}(c=document.ue_backdetect)&&c.ue_back&&(a.ue.bfini=+c.ue_back.value+1);a.ue.isBFonMshop=!0;a.ue.isBFCache=!0;a.ue.t0=b.clickTime;a.ue.viz=["visible:0"];"function"===typeof a.ue.tag&&(a.ue.tag("cacheSourceMemory"),a.ue.tag("history-navigation-page-cache"));c=ue_csm.csa&&ue_csm.csa("SPA");var d=ue_csm.csa&&ue_csm.csa("PageTiming");c&&d&&(c("newPage",{transitionType:"history-navigation-page-cache"},{keepPageAttributes:!0}),d("mark","transitionStart",b.clickTime));"function"===typeof a.uex&&
+a.uex("ld",void 0,void 0,a.ue.t.ld);delete a.ue.isBFonMshop;delete a.ue.isBFCache}})})(ue_csm);
+
+ue_csm.ue.exec(function(e,f){var a=e.ue||{},b=a._wlo,d;if(a.ssw){d=a.ssw("CSM_previousURL").val;var c=f.location,b=b?b:c&&c.href?c.href.split("#")[0]:void 0;c=(b||"")===a.ssw("CSM_previousURL").val;!c&&b&&a.ssw("CSM_previousURL",b);d=c?"reload":d?"intrapage-transition":"first-view"}else d="unknown";a._nt=d},"NavTypeModule")(ue_csm,window);
+ue_csm.ue.exec(function(c,a){function g(a){a.run(function(e){d.tag("csm-feature-"+a.name+":"+e);d.isl&&c.uex("at")})}if(a.addEventListener)for(var d=c.ue||{},f=[{name:"touch-enabled",run:function(b){var e=function(){a.removeEventListener("touchstart",c,!0);a.removeEventListener("mousemove",d,!0)},c=function(){b("true");e()},d=function(){b("false");e()};a.addEventListener("touchstart",c,!0);a.addEventListener("mousemove",d,!0)}}],b=0;b<f.length;b++)g(f[b])},"csm-features")(ue_csm,window);
+
+
+(function(a,e){function d(a){b&&b("recordCounter",a.c,a.v)}var c=e.images,b=a.csa&&a.csa("Metrics",{producerId:"csa"});c&&c.length&&a.ue.count("totalImages",c.length);a.ue.cv.buffer&&b&&(a.ue.cv.buffer.forEach(d),a.ue.cv.buffer.push=d)})(ue_csm,document);
+(function(b){function c(){var d=[];a.log&&a.log.isStub&&a.log.replay(function(a){e(d,a)});a.clog&&a.clog.isStub&&a.clog.replay(function(a){e(d,a)});d.length&&(a._flhs+=1,n(d),p(d))}function g(){a.log&&a.log.isStub&&(a.onflush&&a.onflush.replay&&a.onflush.replay(function(a){a[0]()}),a.onunload&&a.onunload.replay&&a.onunload.replay(function(a){a[0]()}),c())}function e(d,b){var c=b[1],f=b[0],e={};a._lpn[c]=(a._lpn[c]||0)+1;e[c]=f;d.push(e)}function n(b){q&&(a._lpn.csm=(a._lpn.csm||0)+1,b.push({csm:{k:"chk",
+f:a._flhs,l:a._lpn,s:"inln"}}))}function p(a){if(h)a=k(a),b.navigator.sendBeacon(l,a);else{a=k(a);var c=new b[f];c.open("POST",l,!0);c.setRequestHeader&&c.setRequestHeader("Content-type","text/plain");c.send(a)}}function k(a){return JSON.stringify({rid:b.ue_id,sid:b.ue_sid,mid:b.ue_mid,mkt:b.ue_mkt,sn:b.ue_sn,reqs:a})}var f="XMLHttpRequest",q=1===b.ue_ddq,a=b.ue,r=b[f]&&"withCredentials"in new b[f],h=b.navigator&&b.navigator.sendBeacon,l="//"+b.ue_furl+"/1/batch/1/OE/",m=b.ue_fci_ft||5E3;a&&(r||h)&&
+(a._flhs=a._flhs||0,a._lpn=a._lpn||{},a.attach&&(a.attach("beforeunload",a.exec(g,"fcli-bfu")),a.attach("pagehide",a.exec(g,"fcli-ph"))),m&&b.setTimeout(a.exec(c,"fcli-t"),m),a._ffci=a.exec(c))})(window);
+
+
+(function(k,c){function l(a,b){return a.filter(function(a){return a.initiatorType==b})}function f(a,c){if(b.t[a]){var g=b.t[a]-b._t0,e=c.filter(function(a){return 0!==a.responseEnd&&m(a)<g}),f=l(e,"script"),h=l(e,"link"),k=l(e,"img"),n=e.map(function(a){return a.name.split("/")[2]}).filter(function(a,b,c){return a&&c.lastIndexOf(a)==b}),q=e.filter(function(a){return a.duration<p}),s=g-Math.max.apply(null,e.map(m))<r|0;"af"==a&&(b._afjs=f.length);return a+":"+[e[d],f[d],h[d],k[d],n[d],q[d],s].join("-")}}
+function m(a){return a.responseEnd-(b._t0-c.timing.navigationStart)}function n(){var a=c[h]("resource"),d=f("cf",a),g=f("af",a),a=f("ld",a);delete b._rt;b._ld=b.t.ld-b._t0;b._art&&b._art();return[d,g,a].join("_")}var p=20,r=50,d="length",b=k.ue,h="getEntriesByType";b._rre=m;b._rt=c&&c.timing&&c[h]&&n})(ue_csm,window.performance);
+
+
+(function(c,d){var b=c.ue,a=d.navigator;b&&b.tag&&a&&(a=a.connection||a.mozConnection||a.webkitConnection)&&a.type&&b.tag("netInfo:"+a.type)})(ue_csm,window);
+
+
+(function(c,d){function h(a,b){for(var c=[],d=0;d<a.length;d++){var e=a[d],f=b.encode(e);if(e[k]){var g=b.metaSep,e=e[k],l=b.metaPairSep,h=[],m=void 0;for(m in e)e.hasOwnProperty(m)&&h.push(m+"="+e[m]);e=h.join(l);f+=g+e}c.push(f)}return c.join(b.resourceSep)}function s(a){var b=a[k]=a[k]||{};b[t]||(b[t]=c.ue_mid);b[u]||(b[u]=c.ue_sid);b[f]||(b[f]=c.ue_id);b.csm=1;a="//"+c.ue_furl+"/1/"+a[v]+"/1/OP/"+a[w]+"/"+a[x]+"/"+h([a],y);if(n)try{n.call(d[p],a)}catch(g){c.ue.sbf=1,(new Image).src=a}else(new Image).src=
+a}function q(){g&&g.isStub&&g.replay(function(a,b,c){a=a[0];b=a[k]=a[k]||{};b[f]=b[f]||c;s(a)});l.impression=s;g=null}if(!(1<c.ueinit)){var k="metadata",x="impressionType",v="foresterChannel",w="programGroup",t="marketplaceId",u="session",f="requestId",p="navigator",l=c.ue||{},n=d[p]&&d[p].sendBeacon,r=function(a,b,c,d){return{encode:d,resourceSep:a,metaSep:b,metaPairSep:c}},y=r("","?","&",function(a){return h(a.impressionData,z)}),z=r("/",":",",",function(a){return a.featureName+":"+h(a.resources,
+A)}),A=r(",","@","|",function(a){return a.id}),g=l.impression;n?q():(l.attach("load",q),l.attach("beforeunload",q));try{d.P&&d.P.register&&d.P.register("impression-client",function(){})}catch(B){c.ueLogError(B,{logLevel:"WARN"})}}})(ue_csm,window);
+
+
+
+var ue_pty = "AmazonFamilyDigitalOrderApplication";
+
+var ue_spty = "OrderSummary";
+
+
+
+var ue_adb = 4;
+var ue_adb_rtla = 1;
+ue_csm.ue.exec(function(y,a){function t(){if(d&&f){var a;a:{try{a=d.getItem(g);break a}catch(c){}a=void 0}if(a)return b=a,!0}return!1}function u(){if(a.fetch)fetch(m).then(function(a){if(!a.ok)throw Error(a.statusText);return a.text?a.text():null}).then(function(b){b?(-1<b.indexOf("window.ue_adb_chk = 1")&&(a.ue_adb_chk=1),n()):h()})["catch"](h);else e.uels(m,{onerror:h,onload:n})}function h(){b=k;l();if(f)try{d.setItem(g,b)}catch(a){}}function n(){b=1===a.ue_adb_chk?p:k;l();if(f)try{d.setItem(g,
+b)}catch(c){}}function q(){a.ue_adb_rtla&&c&&0<c.ec&&!1===r&&(c.elh=null,ueLogError({m:"Hit Info",fromOnError:1},{logLevel:"INFO",adb:b}),r=!0)}function l(){e.tag(b);e.isl&&a.uex&&uex("at",b);s&&s.updateCsmHit("adb",b);c&&0<c.ec?q():a.ue_adb_rtla&&c&&(c.elh=q)}function v(){return b}if(a.ue_adb){a.ue_fadb=a.ue_fadb||10;var e=a.ue,k="adblk_yes",p="adblk_no",m="https://m.media-amazon.com/images/G/01/csm/showads.v2.js?wppaszoneid=-ad-sidebar.",b="adblk_unk",d;a:{try{d=a.localStorage;break a}catch(z){}d=
+void 0}var g="csm:adb",c=a.ue_err,s=e.cookie,f=void 0!==a.localStorage,w=Math.random()>1-1/a.ue_fadb,r=!1,x=t();w||!x?u():l();a.ue_isAdb=v;a.ue_isAdb.unk="adblk_unk";a.ue_isAdb.no=p;a.ue_isAdb.yes=k}},"adb")(document,window);
+
+
+
+
+(function(c,l,m){function h(a){if(a)try{if(a.id)return"//*[@id='"+a.id+"']";var b,d=1,e;for(e=a.previousSibling;e;e=e.previousSibling)e.nodeName===a.nodeName&&(d+=1);b=d;var c=a.nodeName;1!==b&&(c+="["+b+"]");a.parentNode&&(c=h(a.parentNode)+"/"+c);return c}catch(f){return"DETACHED"}}function f(a){if(a&&a.getAttribute)return a.getAttribute(k)?a.getAttribute(k):f(a.parentElement)}var k="data-cel-widget",g=!1,d=[];(c.ue||{}).isBF=function(){try{var a=JSON.parse(localStorage["csm-bf"]||"[]"),b=0<=a.indexOf(c.ue_id);
+a.unshift(c.ue_id);a=a.slice(0,20);localStorage["csm-bf"]=JSON.stringify(a);return b}catch(d){return!1}}();c.ue_utils={getXPath:h,getFirstAscendingWidget:function(a,b){c.ue_cel&&c.ue_fem?!0===g?b(f(a)):d.push({element:a,callback:b}):b()},notifyWidgetsLabeled:function(){if(!1===g){g=!0;for(var a=f,b=0;b<d.length;b++)if(d[b].hasOwnProperty("callback")&&d[b].hasOwnProperty("element")){var c=d[b].callback,e=d[b].element;"function"===typeof c&&"function"===typeof a&&c(a(e))}d=null}},extractStringValue:function(a){if("string"===
+typeof a)return a}}})(ue_csm,window,document);
+
+
+(function(a){a.ue_cel||(a.ue_cel=function(){function m(a,r){r?r.r=u:r={r:u,c:1};D||(!ue_csm.ue_sclog&&r.clog&&b.clog?b.clog(a,r.ns||s,r):r.glog&&b.glog?b.glog(a,r.ns||s,r):b.log(a,r.ns||s,r))}function n(a,b){"function"===typeof p&&p("log",{schemaId:t+".RdCSI.1",eventType:a,clientData:b},{ent:{page:["requestId"]}})}function c(){var a=q.length;if(0<a){for(var r=[],c=0;c<a;c++){var d=q[c].api;d.ready()?(d.on({ts:b.d,ns:s}),g.push(q[c]),m({k:"mso",n:q[c].name,t:b.d()})):r.push(q[c])}q=r}}function f(){if(!f.executed){for(var a=
+0;a<g.length;a++)g[a].api.off&&g[a].api.off({ts:b.d,ns:s});B();m({k:"eod",t0:b.t0,t:b.d()},{c:1,il:1});f.executed=1;for(a=0;a<g.length;a++)q.push(g[a]);g=[];d(v);d(A)}}function B(a){m({k:"hrt",t:b.d()},{c:1,il:1,n:a});y=Math.min(w,e*y);z()}function z(){d(A);A=k(function(){B(!0)},y)}function x(){f.executed||B()}var l=a.window,k=l.setTimeout,d=l.clearTimeout,e=1.5,w=l.ue_cel_max_hrt||3E4,t="robotdetection",q=[],g=[],s=a.ue_cel_ns||"cel",v,A,b=a.ue,F=a.uet,C=a.uex,u=b.rid,D=a.ue_dsbl_cel,h=l.csa,p,y=
+l.ue_cel_hrt_int||3E3,E=l.requestAnimationFrame||function(a){a()};h&&(p=h("Events",{producerId:t}));if(b.isBF)m({k:"bft",t:b.d()});else{"function"==typeof F&&F("bb","csmCELLSframework",{wb:1});k(c,0);b.onunload(f);if(b.onflush)b.onflush(x);v=k(f,6E5);z();"function"==typeof C&&C("ld","csmCELLSframework",{wb:1});return{registerModule:function(a,r){q.push({name:a,api:r});m({k:"mrg",n:a,t:b.d()});c()},reset:function(a){m({k:"rst",t0:b.t0,t:b.d()});q=q.concat(g);g=[];for(var r=q.length,e=0;e<r;e++)q[e].api.off(),
+q[e].api.reset();u=a||b.rid;c();d(v);v=k(f,6E5);f.executed=0},timeout:function(a,b){return k(function(){E(function(){f.executed||a()})},b)},log:m,csaEventLog:n,off:f}}}())})(ue_csm);
+(function(a){a.ue_pdm||!a.ue_cel||a.ue.isBF||(a.ue_pdm=function(){function m(){try{var b=d.screen;if(b){var c={w:b.width,aw:b.availWidth,h:b.height,ah:b.availHeight,cd:b.colorDepth,pd:b.pixelDepth};g&&g.w===c.w&&g.h===c.h&&g.aw===c.aw&&g.ah===c.ah&&g.pd===c.pd&&g.cd===c.cd||(g=c,g.t=t(),g.k="sci",F(g),D&&h("sci",{h:(g.h||"0")+""}))}var k=e.body||{},f=e.documentElement||{},n={w:Math.max(k.scrollWidth||0,k.offsetWidth||0,f.clientWidth||0,f.scrollWidth||0,f.offsetWidth||0),h:Math.max(k.scrollHeight||
+0,k.offsetHeight||0,f.clientHeight||0,f.scrollHeight||0,f.offsetHeight||0)};s&&s.w===n.w&&s.h===n.h||(s=n,s.t=t(),s.k="doi",F(s));w=a.ue_cel.timeout(m,q);A+=1}catch(p){d.ueLogError&&ueLogError(p,{attribution:"csm-cel-page-module",logLevel:"WARN"})}}function n(){x("ebl","default",!1)}function c(){x("efo","default",!0)}function f(){x("ebl","app",!1)}function B(){x("efo","app",!0)}function z(){d.setTimeout(function(){e[E]?x("ebl","pageviz",!1):x("efo","pageviz",!0)},0)}function x(a,b,c){v!==c&&(F({k:a,
+t:t(),s:b},{ff:!0===c?0:1}),D&&h(a,{t:(t()||"0")+"",s:b}));v=c}function l(){b.attach&&(p&&b.attach(y,z,e),G&&P.when("mash").execute(function(a){a&&a.addEventListener&&(a.addEventListener("appPause",f),a.addEventListener("appResume",B))}),b.attach("blur",n,d),b.attach("focus",c,d))}function k(){b.detach&&(p&&b.detach(y,z,e),G&&P.when("mash").execute(function(a){a&&a.removeEventListener&&(a.removeEventListener("appPause",f),a.removeEventListener("appResume",B))}),b.detach("blur",n,d),b.detach("focus",
+c,d))}var d=a.window,e=a.document,w,t,q,g,s,v=null,A=0,b=a.ue,F=a.ue_cel.log,C=a.uet,u=a.uex,D=d.csa,h=a.ue_cel.csaEventLog,p=!!b.pageViz,y=p&&b.pageViz.event,E=p&&b.pageViz.propHid,G=d.P&&d.P.when;"function"==typeof C&&C("bb","csmCELLSpdm",{wb:1});return{on:function(a){q=a.timespan||500;t=a.ts;l();a=d.location;F({k:"pmd",o:a.origin,p:a.pathname,t:t()});m();"function"==typeof u&&u("ld","csmCELLSpdm",{wb:1})},off:function(a){clearTimeout(w);k();b.count&&b.count("cel.PDM.TotalExecutions",A)},ready:function(){return e.body&&
+a.ue_cel&&a.ue_cel.log},reset:function(){g=s=null}}}(),a.ue_cel&&a.ue_cel.registerModule("page module",a.ue_pdm))})(ue_csm);
+(function(a){a.ue_vpm||!a.ue_cel||a.ue.isBF||(a.ue_vpm=function(){function m(){var a=z(),b={w:k.innerWidth,h:k.innerHeight,x:k.pageXOffset,y:k.pageYOffset};c&&c.w==b.w&&c.h==b.h&&c.x==b.x&&c.y==b.y||(b.t=a,b.k="vpi",c=b,e(c,{clog:1}),s&&v("vpi",{t:(c.t||"0")+"",h:(c.h||"0")+"",y:(c.y||"0")+"",w:(c.w||"0")+"",x:(c.x||"0")+""}));f=0;x=z()-a;l+=1}function n(){f||(f=a.ue_cel.timeout(m,B))}var c,f,B,z,x=0,l=0,k=a.window,d=a.ue,e=a.ue_cel.log,w=a.uet,t=a.uex,q=d.attach,g=d.detach,s=k.csa,v=a.ue_cel.csaEventLog;
+"function"==typeof w&&w("bb","csmCELLSvpm",{wb:1});return{on:function(a){z=a.ts;B=a.timespan||100;m();q&&(q("scroll",n),q("resize",n));"function"==typeof t&&t("ld","csmCELLSvpm",{wb:1})},off:function(a){clearTimeout(f);g&&(g("scroll",n),g("resize",n));d.count&&(d.count("cel.VPI.TotalExecutions",l),d.count("cel.VPI.TotalExecutionTime",x),d.count("cel.VPI.AverageExecutionTime",x/l))},ready:function(){return a.ue_cel&&a.ue_cel.log},reset:function(){c=void 0},getVpi:function(){return c}}}(),a.ue_cel&&
+a.ue_cel.registerModule("viewport module",a.ue_vpm))})(ue_csm);
+(function(a){if(!a.ue_fem&&a.ue_cel&&a.ue_utils){var m=a.ue||{},n=a.window,c=n.document;!m.isBF&&!a.ue_fem&&c.querySelector&&n.getComputedStyle&&[].forEach&&(a.ue_fem=function(){function f(a,b){return a>b?3>a-b:3>b-a}function B(a,b){var c=n.pageXOffset,d=n.pageYOffset,k;a:{try{if(a){var e=a.getBoundingClientRect(),g,m=0===a.offsetWidth&&0===a.offsetHeight;c:{for(var h=a.parentNode,p=e.left||0,w=e.top||0,q=e.width||0,s=e.height||0;h&&h!==document.body;){var l;d:{try{var r=void 0;if(h)var t=h.getBoundingClientRect(),
+r={x:t.left||0,y:t.top||0,w:t.width||0,h:t.height||0};else r=void 0;l=r;break d}catch(I){}l=void 0}var u=window.getComputedStyle(h),v="hidden"===u.overflow,x=v||"hidden"===u.overflowX,y=v||"hidden"===u.overflowY,z=w+s-1<l.y+1||w+1>l.y+l.h-1;if((p+q-1<l.x+1||p+1>l.x+l.w-1)&&x||z&&y){g=!0;break c}h=h.parentNode}g=!1}k={x:e.left+c||0,y:e.top+d||0,w:e.width||0,h:e.height||0,d:(m||g)|0}}else k=void 0;break a}catch(J){}k=void 0}if(k&&!a.cel_b)a.cel_b=k,D({n:a.getAttribute(A),w:a.cel_b.w,h:a.cel_b.h,d:a.cel_b.d,
+x:a.cel_b.x,y:a.cel_b.y,t:b,k:"ewi",cl:a.className},{clog:1});else{if(c=k)c=a.cel_b,d=k,c=d.d===c.d&&1===d.d?!1:!(f(c.x,d.x)&&f(c.y,d.y)&&f(c.w,d.w)&&f(c.h,d.h)&&c.d===d.d);c&&(a.cel_b=k,D({n:a.getAttribute(A),w:a.cel_b.w,h:a.cel_b.h,d:a.cel_b.d,x:a.cel_b.x,y:a.cel_b.y,t:b,k:"ewi"},{clog:1}))}}function z(d,e){var f;f=d.c?c.getElementsByClassName(d.c):d.id?[c.getElementById(d.id)]:c.querySelectorAll(d.s);d.w=[];for(var g=0;g<f.length;g++){var h=f[g];if(h){if(!h.getAttribute(A)){var l=h.getAttribute("cel_widget_id")||
+(d.id_gen||u)(h,g)||h.id;h.setAttribute(A,l)}d.w.push(h);k(Q,h,e)}}!1===C&&(F++,F===b.length&&(C=!0,a.ue_utils.notifyWidgetsLabeled()))}function x(a,b){h.contains(a)||D({n:a.getAttribute(A),t:b,k:"ewd"},{clog:1})}function l(a){K.length&&ue_cel.timeout(function(){if(s){for(var b=R(),c=!1;R()-b<g&&!c;){for(c=S;0<c--&&0<K.length;){var d=K.shift();T[d.type](d.elem,d.time)}c=0===K.length}U++;l(a)}},0)}function k(a,b,c){K.push({type:a,elem:b,time:c})}function d(a,c){for(var d=0;d<b.length;d++)for(var e=
+b[d].w||[],h=0;h<e.length;h++)k(a,e[h],c)}function e(){M||(M=a.ue_cel.timeout(function(){M=null;var c=v();d(W,c);for(var e=0;e<b.length;e++)k(X,b[e],c);0===b.length&&!1===C&&(C=!0,a.ue_utils.notifyWidgetsLabeled());l(c)},q))}function w(){M||N||(N=a.ue_cel.timeout(function(){N=null;var a=v();d(Q,a);l(a)},q))}function t(){return y&&E&&h&&h.contains&&h.getBoundingClientRect&&v}var q=50,g=4.5,s=!1,v,A="data-cel-widget",b=[],F=0,C=!1,u=function(){},D=a.ue_cel.log,h,p,y,E,G=n.MutationObserver||n.WebKitMutationObserver||
+n.MozMutationObserver,r=!!G,H,I,O="DOMAttrModified",L="DOMNodeInserted",J="DOMNodeRemoved",N,M,K=[],U=0,S=null,W="removedWidget",X="updateWidgets",Q="processWidget",T,V=n.performance||{},R=V.now&&function(){return V.now()}||function(){return Date.now()};"function"==typeof uet&&uet("bb","csmCELLSfem",{wb:1});return{on:function(d){function k(){if(t()){T={removedWidget:x,updateWidgets:z,processWidget:B};if(r){var a={attributes:!0,subtree:!0};H=new G(w);I=new G(e);H.observe(h,a);I.observe(h,{childList:!0,
+subtree:!0});I.observe(p,a)}else y.call(h,O,w),y.call(h,L,e),y.call(h,J,e),y.call(p,L,w),y.call(p,J,w);e()}}h=c.body;p=c.head;y=h.addEventListener;E=h.removeEventListener;v=d.ts;b=a.cel_widgets||[];S=d.bs||5;m.deffered?k():m.attach&&m.attach("load",k);"function"==typeof uex&&uex("ld","csmCELLSfem",{wb:1});s=!0},off:function(){t()&&(I&&(I.disconnect(),I=null),H&&(H.disconnect(),H=null),E.call(h,O,w),E.call(h,L,e),E.call(h,J,e),E.call(p,L,w),E.call(p,J,w));m.count&&m.count("cel.widgets.batchesProcessed",
+U);s=!1},ready:function(){return a.ue_cel&&a.ue_cel.log},reset:function(){b=a.cel_widgets||[]}}}(),a.ue_cel&&a.ue_fem&&a.ue_cel.registerModule("features module",a.ue_fem))}})(ue_csm);
+(function(a){!a.ue_mcm&&a.ue_cel&&a.ue_utils&&!a.ue.isBF&&(a.ue_mcm=function(){function m(a,d){var e=a.srcElement||a.target||{},f={k:n,w:(d||{}).ow||(B.body||{}).scrollWidth,h:(d||{}).oh||(B.body||{}).scrollHeight,t:(d||{}).ots||c(),x:a.pageX,y:a.pageY,p:l.getXPath(e),n:e.nodeName};z&&"function"===typeof z.now&&a.timeStamp&&(f.dt=(d||{}).odt||z.now()-a.timeStamp,f.dt=parseFloat(f.dt.toFixed(2)));a.button&&(f.b=a.button);e.href&&(f.r=l.extractStringValue(e.href));e.id&&(f.i=e.id);e.className&&e.className.split&&
+(f.c=e.className.split(/\s+/));x(f,{c:1})}var n="mcm",c,f=a.window,B=f.document,z=f.performance,x=a.ue_cel.log,l=a.ue_utils;return{on:function(k){c=k.ts;a.ue_cel_stub&&a.ue_cel_stub.replayModule(n,m);f.addEventListener&&f.addEventListener("mousedown",m,!0)},off:function(a){f.addEventListener&&f.removeEventListener("mousedown",m,!0)},ready:function(){return a.ue_cel&&a.ue_cel.log},reset:function(){}}}(),a.ue_cel&&a.ue_cel.registerModule("mouse click module",a.ue_mcm))})(ue_csm);
+(function(a){a.ue_mmm||!a.ue_cel||a.ue.isBF||(a.ue_mmm=function(m){function n(a,b){var c={x:a.pageX||a.x||0,y:a.pageY||a.y||0,t:l()};!b&&p&&(c.t-p.t<B||c.x==p.x&&c.y==p.y)||(p=c,u.push(c))}function c(){if(u.length){F=H.now();for(var a=0;a<u.length;a++){var c=u[a],d=a;y=u[h];E=c;var e=void 0;if(!(e=2>d)){e=void 0;a:if(u[d].t-u[d-1].t>f)e=0;else{for(e=h+1;e<d;e++){var g=y,k=E,l=u[e];G=(k.x-g.x)*(g.y-l.y)-(g.x-l.x)*(k.y-g.y);if(G*G/((k.x-g.x)*(k.x-g.x)+(k.y-g.y)*(k.y-g.y))>z){e=0;break a}}e=1}e=!e}(r=
+e)?h=d-1:D.pop();D.push(c)}C=H.now()-F;s=Math.min(s,C);v=Math.max(v,C);A=(A*b+C)/(b+1);b+=1;q({k:x,e:D,min:Math.floor(1E3*s),max:Math.floor(1E3*v),avg:Math.floor(1E3*A)},{c:1});u=[];D=[];h=0}}var f=100,B=20,z=25,x="mmm1",l,k,d=a.window,e=d.document,w=d.setInterval,t=a.ue,q=a.ue_cel.log,g,s=1E3,v=0,A=0,b=0,F,C,u=[],D=[],h=0,p,y,E,G,r,H=m&&m.now&&m||Date.now&&Date||{now:function(){return(new Date).getTime()}};return{on:function(a){l=a.ts;k=a.ns;t.attach&&t.attach("mousemove",n,e);g=w(c,3E3)},off:function(a){k&&
+(p&&n(p,!0),c());clearInterval(g);t.detach&&t.detach("mousemove",n,e)},ready:function(){return a.ue_cel&&a.ue_cel.log},reset:function(){u=[];D=[];h=0;p=null}}}(window.performance),a.ue_cel&&a.ue_cel.registerModule("mouse move module",a.ue_mmm))})(ue_csm);
+
+
+
+ue_csm.ue.exec(function(b,c){var e=function(){},f=function(){return{send:function(b,d){if(d&&b){var a;if(c.XDomainRequest)a=new XDomainRequest,a.onerror=e,a.ontimeout=e,a.onprogress=e,a.onload=e,a.timeout=0;else if(c.XMLHttpRequest){if(a=new XMLHttpRequest,!("withCredentials"in a))throw"";}else a=void 0;if(!a)throw"";a.open("POST",b,!0);a.setRequestHeader&&a.setRequestHeader("Content-type","text/plain");a.send(d)}},isSupported:!0}}(),g=function(){return{send:function(c,d){if(c&&d)if(navigator.sendBeacon(c,
+d))b.ue_sbuimp&&b.ue&&b.ue.ssw&&b.ue.ssw("eelsts","scs");else throw"";},isSupported:!!navigator.sendBeacon&&!(c.cordova&&c.cordova.platformId&&"ios"==c.cordova.platformId)}}();b.ue._ajx=f;b.ue._sBcn=g},"Transportation-clients")(ue_csm,window);
+ue_csm.ue.exec(function(b,k){function B(){for(var a=0;a<arguments.length;a++){var c=arguments[a];try{var g;if(c.isSupported){var f=u.buildPayload(l,e);g=c.send(K,f)}else throw dummyException;return g}catch(d){}}a={m:"All supported clients failed",attribution:"CSMSushiClient_TRANSPORTATION_FAIL",f:"sushi-client.js",logLevel:"ERROR"};C(a,k.ue_err_chan||"jserr");b.ue_err.buffer&&b.ue_err.buffer.push(a)}function m(){if(e.length){for(var a=0;a<n.length;a++)n[a]();B(d._sBcn||{},d._ajx||{});e=[];h={};l=
+{};v=w=r=x=0}}function L(){var a=new Date,c=function(a){return 10>a?"0"+a:a};return Date.prototype.toISOString?a.toISOString():a.getUTCFullYear()+"-"+c(a.getUTCMonth()+1)+"-"+c(a.getUTCDate())+"T"+c(a.getUTCHours())+":"+c(a.getUTCMinutes())+":"+c(a.getUTCSeconds())+"."+String((a.getUTCMilliseconds()/1E3).toFixed(3)).slice(2,5)+"Z"}function y(a){try{return JSON.stringify(a)}catch(c){}return null}function D(a,c,g,f){var q=!1;f=f||{};s++;if(s==E){var p={m:"Max number of Sushi Logs exceeded",f:"sushi-client.js",
+logLevel:"ERROR",attribution:"CSMSushiClient_MAX_CALLS"};C(p,k.ue_err_chan||"jserr");b.ue_err.buffer&&b.ue_err.buffer.push(p)}if(p=!(s>=E))(p=a&&-1<a.constructor.toString().indexOf("Object")&&c&&-1<c.constructor.toString().indexOf("String")&&g&&-1<g.constructor.toString().indexOf("String"))||M++;p&&(d.count&&d.count("Event:"+g,1),a.producerId=a.producerId||c,a.schemaId=a.schemaId||g,a.timestamp=L(),c=Date.now?Date.now():+new Date,g=Math.random().toString().substring(2,12),a.messageId=b.ue_id+"-"+
+c+"-"+g,f&&!f.ssd&&(a.sessionId=a.sessionId||b.ue_sid,a.requestId=a.requestId||b.ue_id,a.obfuscatedMarketplaceId=a.obfuscatedMarketplaceId||b.ue_mid),(c=y(a))?(c=c.length,(e.length==N||r+c>O)&&m(),r+=c,a={data:u.compressEvent(a)},e.push(a),(f||{}).n?0===F?m():v||(v=k.setTimeout(m,F)):w||(w=k.setTimeout(m,P)),q=!0):q=!1);!q&&b.ue_int&&console.error("Invalid JS Nexus API call");return q}function G(){if(!H){for(var a=0;a<z.length;a++)z[a]();for(a=0;a<n.length;a++)n[a]();e.length&&(b.ue_sbuimp&&b.ue&&
+b.ue.ssw&&(a=y({dct:l,evt:e}),b.ue.ssw("eeldata",a),b.ue.ssw("eelsts","unk")),B(d._sBcn||{}));H=!0}}function I(a){z.push(a)}function J(a){n.push(a)}var E=1E3,N=499,O=524288,t=function(){},d=b.ue||{},C=d.log||t,Q=b.uex||t;(b.uet||t)("bb","ue_sushi_v1",{wb:1});var K=b.ue_surl||"https://unagi-na.amazon.com/1/events/com.amazon.csm.nexusclient.gamma",R=["messageId","timestamp"],A="#",e=[],h={},l={},r=0,x=0,M=0,s=0,z=[],n=[],H=!1,v,w,F=void 0===b.ue_hpsi?1E3:b.ue_hpsi,P=void 0===b.ue_lpsi?1E4:b.ue_lpsi,
+u=function(){function a(a){h[a]=A+x++;l[h[a]]=a;return h[a]}function c(b){if(!(b instanceof Function)){if(b instanceof Array){for(var f=[],d=b.length,e=0;e<d;e++)f[e]=c(b[e]);return f}if(b instanceof Object){f={};for(d in b)b.hasOwnProperty(d)&&(f[h[d]?h[d]:a(d)]=-1===R.indexOf(d)?c(b[d]):b[d]);return f}return"string"===typeof b&&(b.length>(A+x).length||b.charAt(0)===A)?h[b]?h[b]:a(b):b}}return{compressEvent:c,buildPayload:function(){return y({cs:{dct:l},events:e})}}}();(function(){if(d.event&&d.event.isStub){if(b.ue_sbuimp&&
+b.ue&&b.ue.ssw){var a=b.ue.ssw("eelsts").val;if(a&&"unk"===a&&(a=b.ue.ssw("eeldata").val)){var c;a:{try{c=JSON.parse(a);break a}catch(g){}c=null}c&&c.evt instanceof Array&&c.dct instanceof Object&&(e=c.evt,l=c.dct,e&&l&&(m(),b.ue.ssw("eeldata","{}"),b.ue.ssw("eelsts","scs")))}}d.event.replay(function(a){a[3]=a[3]||{};a[3].n=1;D.apply(this,a)});d.onSushiUnload.replay(function(a){I(a[0])});d.onSushiFlush.replay(function(a){J(a[0])})}})();d.attach("beforeunload",G);d.attach("pagehide",G);d._cmps=u;d.event=
+D;d.event.reset=function(){s=0};d.onSushiUnload=I;d.onSushiFlush=J;try{k.P&&k.P.register&&k.P.register("sushi-client",t)}catch(S){b.ueLogError(S,{logLevel:"WARN"})}Q("ld","ue_sushi_v1",{wb:1})},"Nxs-JS-Client")(ue_csm,window);
+
+
+ue_csm.ue_unrt = 1500;
+(function(d,b,t){function u(a,g){var c=a.srcElement||a.target||{},b={k:v,t:g.t,dt:g.dt,x:a.pageX,y:a.pageY,p:e.getXPath(c),n:c.nodeName};a.button&&(b.b=a.button);c.type&&(b.ty=c.type);c.href&&(b.r=e.extractStringValue(c.href));c.id&&(b.i=c.id);c.className&&c.className.split&&(b.c=c.className.split(/\s+/));h+=1;e.getFirstAscendingWidget(c,function(a){b.wd=a;d.ue.log(b,r)})}function w(a){if(!x(a.srcElement||a.target)){m+=1;n=!0;var g=f=d.ue.d(),c;p&&"function"===typeof p.now&&a.timeStamp&&(c=p.now()-
+a.timeStamp,c=parseFloat(c.toFixed(2)));s=b.setTimeout(function(){u(a,{t:g,dt:c})},y)}}function z(a){if(a){var b=a.filter(A);a.length!==b.length&&(q=!0,k=d.ue.d(),n&&q&&(k&&f&&d.ue.log({k:B,t:f,m:Math.abs(k-f)},r),l(),q=!1,k=0))}}function A(a){if(!a)return!1;var b="characterData"===a.type?a.target.parentElement:a.target;if(!b||!b.hasAttributes||!b.attributes)return!1;var c={"class":"gw-clock gw-clock-aria s-item-container-height-auto feed-carousel using-mouse kfs-inner-container".split(" "),id:["dealClock",
+"deal_expiry_timer","timer"],role:["timer"]},d=!1;Object.keys(c).forEach(function(a){var e=b.attributes[a]?b.attributes[a].value:"";(c[a]||"").forEach(function(a){-1!==e.indexOf(a)&&(d=!0)})});return d}function x(a){if(!a)return!1;var b=(e.extractStringValue(a.nodeName)||"").toLowerCase(),c=(e.extractStringValue(a.type)||"").toLowerCase(),d=(e.extractStringValue(a.href)||"").toLowerCase();a=(e.extractStringValue(a.id)||"").toLowerCase();var f="checkbox color date datetime-local email file month number password radio range reset search tel text time url week".split(" ");
+if(-1!==["select","textarea","html"].indexOf(b)||"input"===b&&-1!==f.indexOf(c)||"a"===b&&-1!==d.indexOf("http")||-1!==["sitbreaderrightpageturner","sitbreaderleftpageturner","sitbreaderpagecontainer"].indexOf(a))return!0}function l(){n=!1;f=0;b.clearTimeout(s)}function C(){b.ue.onunload(function(){ue.count("armored-cxguardrails.unresponsive-clicks.violations",h);ue.count("armored-cxguardrails.unresponsive-clicks.violationRate",h/m*100||0)})}if(b.MutationObserver&&b.addEventListener&&Object.keys&&
+d&&d.ue&&d.ue.log&&d.ue_unrt&&d.ue_utils){var y=d.ue_unrt,r="cel",v="unr_mcm",B="res_mcm",p=b.performance,e=d.ue_utils,n=!1,f=0,s=0,q=!1,k=0,h=0,m=0;b.addEventListener&&(b.addEventListener("mousedown",w,!0),b.addEventListener("beforeunload",l,!0),b.addEventListener("visibilitychange",l,!0),b.addEventListener("pagehide",l,!0));b.ue&&b.ue.event&&b.ue.onSushiUnload&&b.ue.onunload&&C();(new MutationObserver(z)).observe(t,{childList:!0,attributes:!0,characterData:!0,subtree:!0})}})(ue_csm,window,document);
+
+
+ue_csm.ue.exec(function(g,e){if(e.ue_err){var f="";e.ue_err.errorHandlers||(e.ue_err.errorHandlers=[]);e.ue_err.errorHandlers.push({name:"fctx",handler:function(a){if(!a.logLevel||"FATAL"===a.logLevel)if(f=g.getElementsByTagName("html")[0].innerHTML){var b=f.indexOf("var ue_t0=ue_t0||+new Date();");if(-1!==b){var b=f.substr(0,b).split(String.fromCharCode(10)),d=Math.max(b.length-10-1,0),b=b.slice(d,b.length-1);a.fcsmln=d+b.length+1;a.cinfo=a.cinfo||{};for(var c=0;c<b.length;c++)a.cinfo[d+c+1+""]=
+b[c]}b=f.split(String.fromCharCode(10));a.cinfo=a.cinfo||{};if(!(a.f||void 0===a.l||a.l in a.cinfo))for(c=+a.l-1,d=Math.max(c-5,0),c=Math.min(c+5,b.length-1);d<=c;d++)a.cinfo[d+1+""]=b[d]}}})}},"fatals-context")(document,window);
+
+
+(function(m,b){function c(k){function f(a){a&&"string"===typeof a&&(a=(a=a.match(/^(?:https?:)?\/\/(.*?)(\/|$)/i))&&1<a.length?a[1]:null,a&&a&&("number"===typeof e[a]?e[a]++:e[a]=1))}function d(a){var e=10,d=+new Date;a&&a.timeRemaining?e=a.timeRemaining():a={timeRemaining:function(){return Math.max(0,e-(+new Date-d))}};for(var c=b.performance.getEntries(),k=e;g<c.length&&k>n;)c[g].name&&f(c[g].name),g++,k=a.timeRemaining();g>=c.length?h(!0):l()}function h(a){if(!a){a=m.scripts;var c;if(a)for(var d=
+0;d<a.length;d++)(c=a[d].getAttribute("src"))&&"undefined"!==c&&f(c)}0<Object.keys(e).length&&(p&&ue_csm.ue&&ue_csm.ue.event&&(a={domains:e,pageType:b.ue_pty||null,subPageType:b.ue_spty||null,pageTypeId:b.ue_pti||null},ue_csm.ue_sjslob&&(a.lob=ue_csm.ue_lob||"0"),ue_csm.ue.event(a,"csm","csm.CrossOriginDomains.2")),b.ue_ext=e)}function l(){!0===k?d():b.requestIdleCallback?b.requestIdleCallback(d):b.requestAnimationFrame?b.requestAnimationFrame(d):b.setTimeout(d,100)}function c(){if(b.performance&&
+b.performance.getEntries){var a=b.performance.getEntries();!a||0>=a.length?h(!1):l()}else h(!1)}var e=b.ue_ext||{};b.ue_ext||c();return e}function q(){setTimeout(c,r)}var s=b.ue_dserr||!1,p=!0,n=1,r=2E3,g=0;b.ue_err&&s&&(b.ue_err.errorHandlers||(b.ue_err.errorHandlers=[]),b.ue_err.errorHandlers.push({name:"ext",handler:function(b){if(!b.logLevel||"FATAL"===b.logLevel){var f=c(!0),d=[],h;for(h in f){var f=h,g=f.match(/amazon(\.com?)?\.\w{2,3}$/i);g&&1<g.length||-1!==f.indexOf("amazon-adsystem.com")||
+-1!==f.indexOf("amazonpay.com")||-1!==f.indexOf("cloudfront-labs.amazonaws.com")||d.push(h)}b.ext=d}}}));b.ue&&b.ue.isl?c():b.ue&&ue.attach&&ue.attach("load",q)})(document,window);
+
+
+
+
+
+var ue_wtc_c = 3;
+ue_csm.ue.exec(function(b,e){function l(){for(var a=0;a<f.length;a++)a:for(var d=s.replace(A,f[a])+g[f[a]]+t,c=arguments,b=0;b<c.length;b++)try{c[b].send(d);break a}catch(e){}g={};f=[];n=0;k=p}function u(){B?l(q):l(C,q)}function v(a,m,c){r++;if(r>w)d.count&&1==r-w&&(d.count("WeblabTriggerThresholdReached",1),b.ue_int&&console.error("Number of max call reached. Data will no longer be send"));else{var h=c||{};h&&-1<h.constructor.toString().indexOf(D)&&a&&-1<a.constructor.toString().indexOf(x)&&m&&-1<
+m.constructor.toString().indexOf(x)?(h=b.ue_id,c&&c.rid&&(h=c.rid),c=h,a=encodeURIComponent(",wl="+a+"/"+m),2E3>a.length+p?(2E3<k+a.length&&u(),void 0===g[c]&&(g[c]="",f.push(c)),g[c]+=a,k+=a.length,n||(n=e.setTimeout(u,E))):b.ue_int&&console.error("Invalid API call. The input provided is over 2000 chars.")):d.count&&(d.count("WeblabTriggerImproperAPICall",1),b.ue_int&&console.error("Invalid API call. The input provided does not match the API protocol i.e ue.trigger(String, String, Object)."))}}function F(){d.trigger&&
+d.trigger.isStub&&d.trigger.replay(function(a){v.apply(this,a)})}function y(){z||(f.length&&l(q),z=!0)}var t=":1234",s="//"+b.ue_furl+"/1/remote-weblab-triggers/1/OE/"+b.ue_mid+":"+b.ue_sid+":PLCHLDR_RID$s:wl-client-id%3DCSMTriger",A="PLCHLDR_RID",E=b.wtt||1E4,p=s.length+t.length,w=b.mwtc||2E3,G=1===e.ue_wtc_c,B=3===e.ue_wtc_c,H=e.XMLHttpRequest&&"withCredentials"in new e.XMLHttpRequest,x="String",D="Object",d=b.ue,g={},f=[],k=p,n,z=!1,r=0,C=function(){return{send:function(a){if(H){var b=new e.XMLHttpRequest;
+b.open("GET",a,!0);G&&(b.withCredentials=!0);b.send()}else throw"";}}}(),q=function(){return{send:function(a){(new Image).src=a}}}();e.encodeURIComponent&&(d.attach&&(d.attach("beforeunload",y),d.attach("pagehide",y)),F(),d.trigger=v)},"client-wbl-trg")(ue_csm,window);
+
+
+(function(k,d,h){function f(a,c,b){a&&a.indexOf&&0===a.indexOf("http")&&0!==a.indexOf("https")&&l(s,c,a,b)}function g(a,c,b){a&&a.indexOf&&(location.href.split("#")[0]!=a&&null!==a&&"undefined"!==typeof a||l(t,c,a,b))}function l(a,c,b,e){m[b]||(e=u&&e?n(e):"N/A",d.ueLogError&&d.ueLogError({message:a+c+" : "+b,logLevel:v,stack:"N/A"},{attribution:e}),m[b]=1,p++)}function e(a,c){if(a&&c)for(var b=0;b<a.length;b++)try{c(a[b])}catch(d){}}function q(){return d.performance&&d.performance.getEntriesByType?
+d.performance.getEntriesByType("resource"):[]}function n(a){if(a.id)return"//*[@id='"+a.id+"']";var c;c=1;var b;for(b=a.previousSibling;b;b=b.previousSibling)b.nodeName==a.nodeName&&(c+=1);b=a.nodeName;1!=c&&(b+="["+c+"]");a.parentNode&&(b=n(a.parentNode)+"/"+b);return b}function w(){var a=h.images;a&&a.length&&e(a,function(a){var b=a.getAttribute("src");f(b,"img",a);g(b,"img",a)})}function x(){var a=h.scripts;a&&a.length&&e(a,function(a){var b=a.getAttribute("src");f(b,"script",a);g(b,"script",a)})}
+function y(){var a=h.styleSheets;a&&a.length&&e(a,function(a){if(a=a.ownerNode){var b=a.getAttribute("href");f(b,"style",a);g(b,"style",a)}})}function z(){if(A){var a=q();e(a,function(a){f(a.name,a.initiatorType)})}}function B(){e(q(),function(a){g(a.name,a.initiatorType)})}function r(){var a;a=d.location&&d.location.protocol?d.location.protocol:void 0;"https:"==a&&(z(),w(),x(),y(),B(),p<C&&setTimeout(r,D))}var s="[CSM] Insecure content detected ",t="[CSM] Ajax request to same page detected ",v="WARN",
+m={},p=0,D=k.ue_nsip||1E3,C=5,A=1==k.ue_urt,u=!0;ue_csm.ue_disableNonSecure||(d.performance&&d.performance.setResourceTimingBufferSize&&d.performance.setResourceTimingBufferSize(300),r())})(ue_csm,window,document);
+
+
+var ue_aa_a = "";
+if (ue.trigger && (ue_aa_a === "C" || ue_aa_a === "T1")) {
+    ue.trigger("UEDATA_AA_SERVERSIDE_ASSIGNMENT_CLIENTSIDE_TRIGGER_190249", ue_aa_a);
+}
+(function(f,b){function g(){try{b.PerformanceObserver&&"function"===typeof b.PerformanceObserver&&(a=new b.PerformanceObserver(function(b){c(b.getEntries())}),a.observe(d))}catch(h){k()}}function m(){for(var h=d.entryTypes,a=0;a<h.length;a++)c(b.performance.getEntriesByType(h[a]))}function c(a){if(a&&Array.isArray(a)){for(var c=0,e=0;e<a.length;e++){var d=l.indexOf(a[e].name);if(-1!==d){var g=Math.round(b.performance.timing.navigationStart+a[e].startTime);f.uet(n[d],void 0,void 0,g);c++}}l.length===
+c&&k()}}function k(){a&&a.disconnect&&"function"===typeof a.disconnect&&a.disconnect()}if("function"===typeof f.uet&&b.performance&&"object"===typeof b.performance&&b.performance.getEntriesByType&&"function"===typeof b.performance.getEntriesByType&&b.performance.timing&&"object"===typeof b.performance.timing&&"number"===typeof b.performance.timing.navigationStart){var d={entryTypes:["paint"]},l=["first-paint","first-contentful-paint"],n=["fp","fcp"],a;try{m(),g()}catch(p){f.ueLogError(p,{logLevel:"ERROR",
+attribution:"performanceMetrics"})}}})(ue_csm,window);
+
+
+if (window.csa) {
+    csa("Events")("setEntity", {
+        page:{pageType: "AmazonFamilyDigitalOrderApplication", subPageType: "OrderSummary", pageTypeId: ""}
+    });
+}
+csa.plugin(function(c){var m="transitionStart",n="pageVisible",e="PageTiming",t="visibilitychange",s="$latency.visible",i=c.global,r=(i.performance||{}).timing,a=["navigationStart","unloadEventStart","unloadEventEnd","redirectStart","redirectEnd","fetchStart","domainLookupStart","domainLookupEnd","connectStart","connectEnd","secureConnectionStart","requestStart","responseStart","responseEnd","domLoading","domInteractive","domContentLoadedEventStart","domContentLoadedEventEnd","domComplete","loadEventStart","loadEventEnd"],u=c.config,o=i.Math,l=o.max,g=o.floor,d=i.document||{},f=(r||{}).navigationStart,v=f,p=0,S=null;if(i.Object.keys&&[].forEach&&!u["KillSwitch."+e]){if(!r||null===f||f<=0||void 0===f)return c.error("Invalid navigation timing data: "+f);S=new E({schemaId:"<ns>.PageLatency.6",producerId:"csa"}),"boolean"!=typeof d.hidden&&"string"!=typeof d.visibilityState||!d.removeEventListener?c.emit(s):b()?(c.emit(s),I(n,f)):c.on(d,t,function e(){b()&&(v=c.time(),d.removeEventListener(t,e),I(m,v),I(n,v),c.emit(s))}),c.once("$unload",h),c.once("$load",h),c.on("$pageTransition",function(){v=c.time()}),c.register(e,{mark:I,instance:function(e){return new E(e)}})}function E(e){var i,r=null,a=e.ent||{page:["pageType","subPageType","requestId"]},o=e.logger||c("Events",{producerId:e.producerId,lob:u.lob||"0"});if(!e||!e.producerId||!e.schemaId)return c.error("The producer id and schema Id must be defined for PageLatencyInstance.");function d(){return i||v}function n(){r=c.UUID()}this.mark=function(n,t){if(null!=n)return t=t||c.time(),n===m&&(i=t),c.once(s,function(){o("log",{messageId:r,__merge:function(e){e.markers[n]=function(e,n){return l(0,n-(e||v))}(d(),t),e.markerTimestamps[n]=g(t)},markers:{},markerTimestamps:{},navigationStartTimestamp:d()?new Date(d()).toISOString():null,schemaId:e.schemaId},{ent:a})}),t},n(),c.on("$beforePageTransition",n)}function I(e,n){e===m&&(v=n);var t=S.mark(e,n);c.emit("$timing:"+e,t)}function h(){if(!p){for(var e=0;e<a.length;e++)r[a[e]]&&I(a[e],r[a[e]]);p=1}}function b(){return!d.hidden||"visible"===d.visibilityState}});csa.plugin(function(c){var f,u,l="length",a="parentElement",t="target",i="getEntriesByName",e=null,r="_csa_flt",o="_csa_llt",s="previousSibling",d="visuallyLoaded",n="client",g="offset",h="scroll",m="Width",p="Height",v=n+m,y=n+p,E=g+m,S=g+p,x=h+m,O=h+p,b="_osrc",w="_elt",I="_eid",T=10,_=5,L=15,N=100,k=c.global,B=c.timeout,H=k.Math,W=H.max,C=H.floor,F=H.ceil,M=k.document||{},R=M.body||{},Y=M.documentElement||{},P=k.performance||{},X=(P.timing||{}).navigationStart,$=Date.now,D=Object.values||(c.types||{}).ovl,J=c("PageTiming"),V=c("SpeedIndexBuffers"),j=[],q=[],z=[],A=[],G=[],K=[],Q=.1,U=.1,Z=0,ee=0,ne=!0,te=0,ie=0,re=1==c.config["SpeedIndex.ForceReplay"],oe=0,ae=1,fe=0,ce={},ue=[],le=0;function se(){for(var e=$(),n=0;f;){if(0!==f[l]){if(!1!==f.h(f[0])&&f.shift(),n++,!re&&n%T==0&&$()-e>_)break}else f=f.n}Z=0,f&&(Z||(!0===M.hidden?(re=1,se()):c.timeout(se,0)))}function de(e,n,t,i,r){fe=C(e),j=n,q=t,z=i,K=r;var o=M.createTreeWalker(M.body,NodeFilter.SHOW_TEXT,null,null),a={w:k.innerWidth,h:k.innerHeight,x:k.pageXOffset,y:k.pageYOffset};M.body[w]=e,A.push({w:o,vp:a}),G.push({img:M.images,iter:0}),j.h=ge,(j.n=q).h=he,(q.n=z).h=me,(z.n=A).h=pe,(A.n=G).h=ve,(G.n=K).h=ye,f=j,se()}function ge(e){e.m.forEach(function(e){for(var n=e;n&&(e===n||!n[r]||!n[o]);)n[r]||(n[r]=e[r]),n[o]||(n[o]=e[o]),n[w]=n[r]-X,n=n[s]})}function he(e){e.m.forEach(function(e){var n=e[t];b in n||(n[b]=e.oldValue)})}function me(n){n.m.forEach(function(e){e[t][w]=n.t-X})}function pe(e){for(var n,t=e.vp,i=e.w,r=T;(n=i.nextNode())&&0<r;){r-=1;var o=(n[a]||{}).nodeName;"SCRIPT"!==o&&"STYLE"!==o&&"NOSCRIPT"!==o&&"BODY"!==o&&0!==(n.nodeValue||"").trim()[l]&&be(n[a],Ee(n),t)}return!n}function ve(e){for(var n={w:k.innerWidth,h:k.innerHeight,x:k.pageXOffset,y:k.pageYOffset},t=T;e.iter<e.img[l]&&0<t;){var i,r=e.img[e.iter],o=Oe(r),a=o&&Ee(o)||Ee(r);o?(o[w]=a,i=xe(o.querySelector('[aria-posinset="1"] img')||r)||a,r=o):i=xe(r)||a,ie&&u<i&&(i=a),be(r,i,n),e.iter+=1,t-=1}return e.img[l]<=e.iter}function ye(e){var n=[],i=0,r=0,o=ee,t=k.innerHeight||W(R[O]||0,R[S]||0,Y[y]||0,Y[O]||0,Y[S]||0),a=C(e.y/N),f=F((e.y+t)/N);ue.slice(a,f).forEach(function(e){(e.elems||[]).forEach(function(e){e.lt in n||(n[e.lt]={}),e.id in n[e.lt]||(i+=(n[e.lt][e.id]=e).a)})}),D(n).forEach(function(e){D(e).forEach(function(e){var n=1-r/i,t=W(e.lt,o);le+=n*(t-o),o=t,function(e,n){var t;for(;Q<=1&&Q-.01<=e;)we(d+(t=(100*Q).toFixed(0)),n.lt),"50"!==t&&"90"!==t||c("Content",{target:n.e})("mark",d+t,X+F(n.lt||0)),Q+=U}((r+=e.a)/i,e)})}),ee=e.t-X,K[l]<=1&&(we("speedIndex",le),we(d+"0",fe)),ne&&(ne=!1,we("atfSpeedIndex",le))}function Ee(e){for(var n=e[a],t=L;n&&0<t;){if(n[w]||0===n[w])return W(n[w],fe);n=n.parentElement,t-=1}}function Se(e,n){if(e){if(!e.indexOf("data:"))return Ee(n);var t=P[i](e)||[];if(0<t[l])return W(F(t[0].responseEnd||0),fe)}}function xe(e){return Se(e[b],e)||Se(e.currentSrc,e)||Se(e.src,e)}function Oe(e){for(var n=10,t=e.parentElement;t&&0<n;){if(t.classList&&t.classList.contains("a-carousel-viewport"))return t;t=t.parentElement,n-=1}return null}function be(e,n,t){if((n||0===n)&&!e[I]){var i=e.getBoundingClientRect(),r=i.width*i.height,o=t.w||W(R[x]||0,R[E]||0,Y[v]||0,Y[x]||0,Y[E]||0)||i.right,a=i.width/2,f=ae++;if(0!=r&&!(a<i.right-o||i.right<a)){for(var c={e:e,lt:n,a:r,id:f},u=C((i.top+t.y)/N),l=F((i.top+t.y+i.height)/N),s=u;s<=l;s++)s in ue||(ue[s]={elems:[],lt:0}),ue[s].elems.push(c);e[I]=f}}}function we(e,n){J("mark",e,X+F((ce[e]=n)||0))}function Ie(e){oe||(V("getBuffers",de),oe=1)}X&&D&&P[i]&&(V("registerListener",function(){ie&&(clearTimeout(te),te=B(Ie.bind(e,"Mut"),2500))}),c.once("$unload",function(){re=1,Ie()}),c.once("$load",function(){ie=1,u=$()-X,te=B(Ie.bind(e,"Ld"),2500)}),c.once("$timing:functional",Ie.bind(e,"Fn")),V("replayModuleIsLive"),c.register("SpeedIndex",{getMarkers:function(e){e&&e(JSON.parse(JSON.stringify(ce)))}}))});csa.plugin(function(e){var m=!!e.config["LCP.elementDedup"],t=!1,n=e("PageTiming"),r=e.global.PerformanceObserver,a=e.global.performance;function i(){return a.timing.navigationStart}function o(){t||function(o){var l=new r(function(e){var t=e.getEntries();if(0!==t.length){var n=t[t.length-1];if(m&&""!==n.id&&n.element&&"IMG"===n.element.tagName){for(var r={},a=t[0],i=0;i<t.length;i++)t[i].id in r||(""!==t[i].id&&(r[t[i].id]=!0),a.startTime<t[i].startTime&&(a=t[i]));n=a}l.disconnect(),o({startTime:n.startTime,renderTime:n.renderTime,loadTime:n.loadTime})}});try{l.observe({type:"largest-contentful-paint",buffered:!0})}catch(e){}}(function(e){e&&(t=!0,n("mark","largestContentfulPaint",Math.floor(e.startTime+i())),e.renderTime&&n("mark","largestContentfulPaint.render",Math.floor(e.renderTime+i())),e.loadTime&&n("mark","largestContentfulPaint.load",Math.floor(e.loadTime+i())))})}r&&a&&a.timing&&(e.once("$unload",o),e.once("$load",o),e.register("LargestContentfulPaint",{}))});csa.plugin(function(r){var e=r("Metrics",{producerId:"csa"}),n=r.global.PerformanceObserver;n&&(n=new n(function(r){var t=r.getEntries();if(0===t.length||!t[0].processingStart||!t[0].startTime)return;!function(r){r=r||0,n.disconnect(),0<=r?e("recordMetric","firstInputDelay",r):e("recordMetric","firstInputDelay.invalid",1)}(t[0].processingStart-t[0].startTime)}),function(){try{n.observe({type:"first-input",buffered:!0})}catch(r){}}())});csa.plugin(function(d){var e="Metrics",g=d.config,f=0;function r(i){var c,t,e=i.producerId,r=i.logger,o=r||d("Events",{producerId:e,lob:g.lob||"0"}),s=(i||{}).dimensions||{},u={},n=-1;if(!e&&!r)return d.error("Either a producer id or custom logger must be defined");function a(){n!==f&&(c=d.UUID(),t=d.UUID(),u={},n=f)}this.recordMetric=function(r,n){var e=i.logOptions||{ent:{page:["pageType","subPageType","requestId"]}};e.debugMetric=i.debugMetric,a(),o("log",{messageId:c,schemaId:i.schemaId||"<ns>.Metric.4",metrics:{},dimensions:s,__merge:function(e){e.metrics[r]=n}},e)},this.recordCounter=function(r,e){var n=i.logOptions||{ent:{page:["pageType","subPageType","requestId"]}};if("string"!=typeof r||"number"!=typeof e||!isFinite(e))return d.error("Invalid type given for counter name or counter value: "+r+"/"+e);a(),r in u||(u[r]={});var c=u[r];"f"in c||(c.f=e),c.c=(c.c||0)+1,c.s=(c.s||0)+e,c.l=e,o("log",{messageId:t,schemaId:i.schemaId||"<ns>.InternalCounters.3",c:{},__merge:function(e){r in e.c||(e.c[r]={}),c.fs||(c.fs=1,e.c[r].f=c.f),1<c.c&&(e.c[r].s=c.s,e.c[r].l=c.l,e.c[r].c=c.c)}},n)}}g["KillSwitch."+e]||(new r({producerId:"csa"}).recordMetric("baselineMetricEvent",1),d.on("$beforePageTransition",function(){f++}),d.register(e,{instance:function(e){return new r(e||{})}}))});csa.plugin(function(s){var n=s.config,r=(s.global.performance||{}).timing,c=(r||{}).navigationStart||s.time(),g=0;function e(){g+=1}function i(i){i=i||{};var o=s.UUID(),t=g,r=i.producerId,e=i.logger,a=e||s("Events",{producerId:r,lob:n.lob||"0"});if(!r&&!e)return s.error("Either a producer id or custom logger must be defined");this.mark=function(e,r){var n=(void 0===r?s.time():r)-c;t!==g&&(t=g,o=s.UUID()),a("log",{messageId:o,schemaId:i.schemaId||"<ns>.Timer.1",markers:{},__merge:function(r){r.markers[e]=n}},i.logOptions)}}r&&(e(),s.on("$beforePageTransition",e),s.register("Timers",{instance:function(r){return new i(r||{})}}))});csa.plugin(function(t){var e="takeRecords",i="disconnect",n="function",o=t("Metrics",{producerId:"csa"}),c=t("PageTiming"),a=t.global,u=t.timeout,r=t.on,f=a.PerformanceObserver,m=0,l=!1,s=0,d=a.performance,h=a.document,v=null,y=!1,g=t.blank;function p(){l||(l=!0,clearTimeout(v),typeof f[e]===n&&f[e](),typeof f[i]===n&&f[i](),o("recordMetric","documentCumulativeLayoutShift",m),c("mark","cumulativeLayoutShiftLastTimestamp",Math.floor(s+d.timing.navigationStart)))}f&&d&&d.timing&&h&&(f=new f(function(t){v&&clearTimeout(v);t.getEntries().forEach(function(t){t.hadRecentInput||(m+=t.value,s<t.startTime&&(s=t.startTime))}),v=u(p,5e3)}),function(){try{f.observe({type:"layout-shift",buffered:!0}),v=u(p,5e3)}catch(t){}}(),g=r(h,"click",function(t){y||(y=!0,o("recordMetric","documentCumulativeLayoutShiftToFirstInput",m),g())}),r(h,"visibilitychange",function(){"hidden"===h.visibilityState&&p()}),t.once("$unload",p))});csa.plugin(function(e){var t,n=e.global,r=n.PerformanceObserver,c=e("Metrics",{producerId:"csa"}),o=0,i=0,a=-1,l=n.Math,f=l.max,u=l.ceil;if(r){t=new r(function(e){e.getEntries().forEach(function(e){var t=e.duration;o+=t,i+=t,a=f(t,a)})});try{t.observe({type:"longtask",buffered:!0})}catch(e){}t=new r(function(e){0<e.getEntries().length&&(i=0,a=-1)});try{t.observe({type:"largest-contentful-paint",buffered:!0})}catch(e){}e.on("$unload",g),e.on("$beforePageTransition",g)}function g(){c("recordMetric","totalBlockingTime",u(i||0)),c("recordMetric","totalBlockingTimeInclLCP",u(o||0)),c("recordMetric","maxBlockingTime",u(a||0)),i=o=0,a=-1}});csa.plugin(function(o){var e="CacheDetection",r="csa-ctoken-",c=o.store,t=o.deleteStored,n=o.config,i=n[e+".RequestID"],a=n[e+".Callback"],s=o.global,u=s.document||{},d=s.Date,l=o("Events"),f=o("Events",{producerId:"csa",lob:n.lob||"0"});function p(e){try{var c=u.cookie.match(RegExp("(^| )"+e+"=([^;]+)"));return c&&c[2].trim()}catch(e){}}n["KillSwitch."+e]||(function(){var e=function(){var e=p("cdn-rid");if(e)return{r:e,s:"cdn"}}()||function(){if(o.store(r+i))return{r:o.UUID().toUpperCase().replace(/-/g,"").slice(0,20),s:"device"}}()||{},c=e.r,n=e.s;if(!!c){var t=p("session-id");!function(e,c,n,t){l("setEntity",{page:{pageSource:"cache",requestId:e,cacheRequestId:i,cacheSource:t},session:{id:n}})}(c,0,t,n),"device"===n&&f("log",{schemaId:"<ns>.CacheImpression.2"},{ent:"all"}),a&&a(c,t,n)}}(),c(r+i,d.now()+36e5),o.once("$load",function(){var n=d.now();t(function(e,c){return 0==e.indexOf(r)&&parseInt(c)<n})}))});csa.plugin(function(u){var i,t="Content",e="MutationObserver",n="addedNodes",a="querySelectorAll",f="matches",r="getAttributeNames",o="getAttribute",s="dataset",c="widget",l="producerId",d="slotId",h="iSlotId",g={ent:{element:1,page:["pageType","subPageType","requestId"]}},p=5,m=u.config[t+".BubbleUp.SearchDepth"]||35,y=u.config[t+".SearchPage"]||0,v="csaC",b=v+"Id",E="logRender",w={},I=u.config,O=I[t+".Selectors"]||[],C=I[t+".WhitelistedAttributes"]||{href:1,class:1},N=I[t+".EnableContentEntities"],S=I["KillSwitch.ContentRendered"],k=u.global,A=k.document||{},U=A.documentElement,L=k.HTMLElement,R={},_=[],j=function(t,e,n,i){var o=this,r=u("Events",{producerId:t||"csa",lob:I.lob||"0"});e.type=e.type||c,o.id=e.id,o.l=r,o.e=e,o.el=n,o.rt=i,o.dlo=g,o.op=W(n,"csaOp"),o.log=function(t,e){r("log",t,e||g)},o.entities=function(t){t(e)},e.id&&r("setEntity",{element:e})},x=j.prototype;function D(t){var e=(t=t||{}).element,n=t.target;return e?function(t,e){var n;n=t instanceof L?K(t)||Y(e[l],t,z,u.time()):R[t.id]||H(e[l],0,t,u.time());return n}(e,t):n?M(n):u.error("No element or target argument provided.")}function M(t){var e=function(t){var e=null,n=0;for(;t&&n<m;){if(n++,P(t,b)){e=t;break}t=t.parentElement}return e}(t);return e?K(e):new j("csa",{id:null},null,u.time())}function P(t,e){if(t&&t.dataset)return t.dataset[e]}function T(t,e,n){_.push({n:n,e:t,t:e}),B()}function q(){for(var t=u.time(),e=0;0<_.length;){var n=_.shift();if(w[n.n](n.e,n.t),++e%10==0&&u.time()-t>p)break}i=0,_.length&&B()}function B(){i=i||u.raf(q)}function X(t,e,n){return{n:t,e:e,t:n}}function Y(t,e,n,i){var o=u.UUID(),r={id:o},c=M(e);return e[s][b]=o,n(r,e),c&&c.id&&(r.parentId=c.id),H(t,e,r,i)}function $(t){return isNaN(t)?null:Math.round(t)}function H(t,e,n,i){N&&(n.schemaId="<ns>.ContentEntity.2"),n.id=n.id||u.UUID();var o=new j(t,n,e,i);return function(t){return!S&&((t.op||{}).hasOwnProperty(E)||y)}(o)&&function(t,e){var n={},i=u.exec($);t.el&&(n=t.el.getBoundingClientRect()),t.log({schemaId:"<ns>.ContentRender.3",timestamp:e,width:i(n.width),height:i(n.height),positionX:i(n.left+k.pageXOffset),positionY:i(n.top+k.pageYOffset)})}(o,i),u.emit("$content.register",o),R[n.id]=o}function K(t){return R[(t[s]||{})[b]]}function W(n,i){var o={};return r in(n=n||{})&&Object.keys(n[s]).forEach(function(t){if(!t.indexOf(i)&&i.length<t.length){var e=function(t){return(t[0]||"").toLowerCase()+t.slice(1)}(t.slice(i.length));o[e]=n[s][t]}}),o}function z(t,e){r in e&&(function(t,e){var n=W(t,v);Object.keys(n).forEach(function(t){e[t]=n[t]})}(e,t),d in t&&(t[h]=t[d]),function(e,n){(e[r]()||[]).forEach(function(t){t in C&&(n[t]=e[o](t))})}(e,t))}U&&A[a]&&k[e]&&(O.push({selector:"*[data-csa-c-type]",entity:z}),O.push({selector:".celwidget",entity:function(t,e){z(t,e),t[d]=t[d]||e[o]("cel_widget_id")||e.id,t.legacyId=e[o]("cel_widget_id")||e.id,t.type=t.type||c}}),w[1]=function(t,e){t.forEach(function(t){t[n]&&t[n].constructor&&"NodeList"===t[n].constructor.name&&Array.prototype.forEach.call(t[n],function(t){_.unshift(X(2,t,e))})})},w[2]=function(r,c){a in r&&f in r&&O.forEach(function(t){for(var e=t.selector,n=r[f](e),i=r[a](e),o=i.length-1;0<=o;o--)_.unshift(X(3,{e:i[o],s:t},c));n&&_.unshift(X(3,{e:r,s:t},c))})},w[3]=function(t,e){var n=t.e;K(n)||Y("csa",n,t.s.entity,e)},w[4]=function(){u.register(t,{instance:D})},new k[e](function(t){T(t,u.time(),1)}).observe(U,{childList:!0,subtree:!0}),T(U,u.time(),2),T(null,u.time(),4),u.on("$content.export",function(e){Object.keys(e).forEach(function(t){x[t]=e[t]})}))});csa.plugin(function(o){var i,t="ContentImpressions",e="KillSwitch.",n="IntersectionObserver",r="getAttribute",s="dataset",c="intersectionRatio",a="csaCId",m=1e3,l=o.global,f=o.config,u=f[e+t],v=f[e+t+".ContentViews"],g=((l.performance||{}).timing||{}).navigationStart||o.time(),d={};function h(t){t&&(t.v=1,function(t){t.vt=o.time(),t.el.log({schemaId:"<ns>.ContentView.4",timeToViewed:t.vt-t.el.rt,pageFirstPaintToElementViewed:t.vt-g})}(t))}function I(t){t&&!t.it&&(t.i=o.time()-t.is>m,function(t){t.it=o.time(),t.el.log({schemaId:"<ns>.ContentImpressed.3",timeToImpressed:t.it-t.el.rt,pageFirstPaintToElementImpressed:t.it-g})}(t))}!u&&l[n]&&(i=new l[n](function(t){var n=o.time();t.forEach(function(t){var e=function(t){if(t&&t[r])return d[t[s][a]]}(t.target);if(e){o.emit("$content.intersection",{meta:e.el,t:n,e:t});var i=t.intersectionRect;t.isIntersecting&&0<i.width&&0<i.height&&(v||e.v||h(e),.5<=t[c]&&!e.is&&(e.is=n,e.timer=o.timeout(function(){I(e)},m))),t[c]<.5&&!e.it&&e.timer&&(l.clearTimeout(e.timer),e.is=0,e.timer=0)}})},{threshold:[0,.5,.99]}),o.on("$content.register",function(t){var e=t.el;e&&(d[t.id]={el:t,v:0,i:0,is:0,vt:0,it:0},i.observe(e))}))});csa.plugin(function(e){e.config["KillSwitch.ContentLatency"]||e.emit("$content.export",{mark:function(t,n){var o=this;o.t||(o.t=e("Timers",{logger:o.l,schemaId:"<ns>.ContentLatency.4",logOptions:o.dlo})),o.t("mark",t,n)}})});csa.plugin(function(t){function n(i,e,o){var c={};function r(t,n,e){t in c&&o<=n-c[t].s&&(function(n,e,i){if(!p)return;E(function(t){T(n,t),t.w[n][e]=a((t.w[n][e]||0)+i)})}(t,i,n-c[t].d),c[t].d=n),e||delete c[t]}this.update=function(t,n){n.isIntersecting&&e<=n.intersectionRatio?function(t,n){t in c||(c[t]={s:n,d:n})}(t,u()):r(t,u())},this.stopAll=function(t){var n=u();for(var e in c)r(e,n,t)},this.reset=function(){var t=u();for(var n in c)c[n].s=t,c[n].d=t}}var e=t.config,u=t.time,i="ContentInteractionsSummary",o=e[i+".FlushInterval"]||5e3,c=e[i+".FlushBackoff"]||1.5,r=t.global,s=t.on,a=Math.floor,f=(r.document||{}).documentElement||{},l=((r.performance||{}).timing||{}).responseStart||t.time(),d=o,m=0,p=!0,v=t.UUID(),g=t("Events",{producerId:"csa",lob:e.lob||"0"}),w=new n("it0",0,0),I=new n("it50",.5,1e3),h=new n("it100",.99,0),b={},A={};function $(){w.stopAll(!0),I.stopAll(!0),h.stopAll(!0),S()}function C(){w.reset(),I.reset(),h.reset(),S()}function S(){d&&(clearTimeout(m),m=t.timeout($,d),d*=c)}function U(n){E(function(t){T(n,t),t.w[n].mc=(t.w[n].mc||0)+1})}function E(t){g("log",{messageId:v,schemaId:"<ns>.ContentInteractionsSummary.2",w:{},__merge:t},{ent:{page:["requestId"]}})}function T(t,n){t in n.w||(n.w[t]={})}e["KillSwitch."+i]||(s("$content.intersection",function(t){if(t&&t.meta&&t.e){var n=t.meta.id;if(n in b){var e=t.e.boundingClientRect||{};e.width<5||e.height<5||(w.update(n,t.e),I.update(n,t.e),h.update(n,t.e),!t.e.isIntersecting||n in A||(A[n]=1,function(n,e){E(function(t){T(n,t),t.w[n].ttfv=a(e)})}(n,u()-l)))}}}),s("$content.register",function(t){(t.e||{}).slotId&&(b[t.id]={},function(e){E(function(t){var n=e.id;T(n,t),t.w[n].sid=(e.e||{}).slotId,t.w[n].cid=(e.e||{}).contentId})}(t))}),s("$beforePageTransition",function(){$(),C(),v=t.UUID(),S()}),s("$beforeunload",function(){w.stopAll(),I.stopAll(),h.stopAll(),d=null}),s("$visible",function(t){t?C():($(),clearTimeout(m)),p=t},{buffered:1}),s(f,"click",function(t){for(var n=t.target,e=25;n&&0<e;){var i=(n.dataset||{}).csaCId;i&&U(i),n=n.parentElement,e-=1}},{capture:!0,passive:!0}),S())});csa.plugin(function(d){var t,o,e="normal",c="reload",i="history",s="new-tab",n="ajax",r=1,a=2,u="lastActive",l="lastInteraction",f="used",p="csa-tabbed-browsing",y="visibilityState",g="page",v="experience",b="request",I="initialized",m={"back-memory-cache":1,"tab-switch":1,"history-navigation-page-cache":1},h="TabbedBrowsing",T="<ns>."+h+".4",S="visible",w=d.global,x=d.config,P=d("Events",{producerId:"csa",lob:x.lob||"0"}),q=w.location||{},z=w.document,A=w.JSON,C=((w.performance||{}).navigation||{}).type,E=d.store,O=d.on,$=d.storageSupport(),k=!1,R={},j={},B={},J={},K={},M=!1,N=!1,D=!1,F=0,G=x["CSA.isRunningInsideMShop"];function H(e){try{return A.parse(E(p,void 0,{session:e})||"{}")||{}}catch(e){d.error('Could not parse storage value for key "'+p+'": '+e)}return{}}function L(e,i){E(p,A.stringify(i||{}),{session:e})}function Q(e){var i=j.tid||e.id,t={},n=R[u]||{};for(var r in n)n.hasOwnProperty(r)&&(t[r]=n[r]);!G&&t.tid!==i||(t.tid=i,t.pid=e.id,t.ent=K),J={pid:e.id,tid:i,ent:K,lastInteraction:j[l]||{},initialized:!0},B={lastActive:t,lastInteraction:R[l]||{},time:d.time(),initialized:!0}}function U(e){var i=e===s,t=z.referrer,n=!(t&&t.length)||!~t.indexOf(q.origin||""),r=i&&!G&&n,a={type:e,toTabId:J.tid,toPageId:J.pid,transitTime:d.time()-R.time||null};r||function(e,i,t){var n=e===c,r=i||G&&!(j[I]&&j.ent)?R[u]||{}:j,a=R[l]||{},d=j[l]||{},o=i||G&&!(d.id&&!d[f])?a:d;t.fromTabId=r.tid,t.fromPageId=r.pid;var s=r.ent||{};s.rid&&(t.fromRequestId=s.rid||null),s.ety&&(t.fromExperienceType=s.ety||null),s.esty&&(t.fromExperienceSubType=s.esty||null),n||!o.id||o[f]||(t.interactionId=o.id||null,o.sid&&(t.interactionSlotId=o.sid||null),a.id===o.id&&(a[f]=!0),d.id===o.id&&(d[f]=!0))}(e,i,a),P("log",{navigation:a,schemaId:T},{ent:{page:["pageType","subPageType","requestId"]}})}function V(e){D=function(e){return e&&e in m}(e.transitionType),function(){R=H(!1),j=H(!0);var e=R[l],i=j[l],t=!1,n=!1;e&&i&&e.id===i.id&&e[f]!==i[f]&&(t=!e[f],n=!i[f],i[f]=e[f]=!0,t&&L(!1,R),n&&L(!0,j))}(),Q(e),M=!0,function(e){var i,t;i=X(),t=Z(!0),(i||t)&&Q(e)}(e),F=1}function W(){k&&!D?U(n):(k=!0,function(){if(C===a||D)U(i);else if(C===r)U(j[I]?c:s);else{U(j[I]||G&&R[I]?e:s)}}())}function X(){var e=t,i={};return!!(M&&e&&e.e&&e.w)&&(e.w("entities",function(e){i=e||{}}),j[l]={id:e.e.messageId,sid:i.slotId,used:!(R[l]={id:e.e.messageId,sid:i.slotId,used:!1})},!(t=null))}function Y(e,i,t,n){var r=!1,a=e[u];return N?(!a||a.tid!==J.tid||!a[S]||a.pid!==t||!a.ent&&n||n&&function(e,i){var t=e||{},n=i||{};return t.rid!==n.rid||t.ety!==n.ety||t.esty!==n.esty}(a.ent,n))&&(e[u]={visible:!0,pid:t,tid:i,ent:n},r=!0):!G&&a&&a.tid===J.tid&&a[S]&&(r=!(a[S]=!1)),r}function Z(e){var i=!1;if(N=G&&e||z[y]===S,M){var t=R[u]||{};i=Y(R,j.tid||t.tid||J.tid,j.pid||t.pid||J.pid,j.ent||t.ent||J.ent)}return i}x["KillSwitch."+h]||$.local&&$.session&&A&&z&&y in z&&(o=function(){try{return w.self!==w.top}catch(e){return!0}}(),O("$entities.set",function(e){if(!o&&e){var i=(e[b]||{}).id||(e[g]||{}).requestId,t=(e[v]||{}).experienceType||(e[g]||{}).pageType,n=(e[v]||{}).experienceSubType||(e[g]||{}).subPageType,r=!K.rid&&i||!K.ety&&t||!K.esty&&n;if(K.rid=K.rid||i,K.ety=K.ety||t,K.esty=K.esty||n,r&&F){var a=R[u]||{};a.tid===j.tid&&(a.ent=K,L(!1,R)),j.ent=K,L(!0,j)}}},{buffered:1}),O("$pageChange",function(e){o||(V(e),W(),L(!1,B),L(!0,J),j=J,R=B)},{buffered:1}),O("$content.interaction",function(e){t=e,X()&&(L(!1,R),L(!0,j))}),O(z,"visibilitychange",function(){!o&&Z()&&L(!1,R)},{capture:!1,passive:!0}))});csa.plugin(function(c){var e=c("Metrics",{producerId:"csa"});c.on(c.global,"pageshow",function(c){c&&c.persisted&&e("recordMetric","bfCache",1)})});csa.plugin(function(n){var e,t,i,o,r,a,c,u,f,s,l,d,p,g,m,v,h,b,y="hasFocus",S="$app.",T="avail",$="client",w="document",I="inner",P="offset",D="screen",C="scroll",E="Width",F="Height",O=T+E,q=T+F,x=$+E,z=$+F,H=I+E,K=I+F,M=P+E,W=P+F,X=C+E,Y=C+F,j="up",k="down",A="none",B=20,G=n.config,J=G["KillSwitch.PageInteractionsSummary"],L=n("Events",{producerId:"csa",lob:G.lob||"0"}),N=1,Q=n.global||{},R=n.time,U=n.on,V=n.once,Z=Q[w]||{},_=Q[D]||{},nn=Q.Math||{},en=nn.abs,tn=nn.max,on=nn.ceil,rn=((Q.performance||{}).timing||{}).responseStart,an=function(){return Z[y]()},cn=1,un=100,fn={},sn=1,ln=0,dn=0,pn=k,gn=A;function mn(){c=t=o=r=e,i=d=0,a=u=f=s=l=0,pn=k,gn=A,dn=ln=0,yn(),bn()}function vn(){rn&&!o&&(c=on((o=p)-rn),sn=1)}function hn(){var n=m-i;(!t||t&&t<=p)&&(n&&(++a,sn=dn=1),i=m,n),function(){if(gn=d<m?k:j,pn!==gn){var n=en(m-d);B<n&&(++l,ln&&!dn&&++a,pn=gn,sn=ln=1,d=m,dn=0)}else dn=0,d=m}(),t=p+un}function bn(){u=on(tn(u,m+b)),g&&(f=on(tn(f,g+h))),sn=1}function yn(){p=R(),g=en(Q.pageXOffset||0),m=tn(Q.pageYOffset||0,0),v=0<g||0<m,h=Q[H]||0,b=Q[K]||0}function Sn(){yn(),vn(),hn(),bn()}function Tn(){if(r){var n=on(R()-r);s+=n,r=e,sn=0<n}}function $n(){r=r||R()}function wn(n,e,t,i){e[n+E]=on(t||0),e[n+F]=on(i||0)}function In(n){var e=n===fn,t=an();if(t||sn){if(!e){if(!N)return;N=0,t&&Tn()}var i=function(){var n={},e=Z.documentElement||{},t=Z.body||{};return wn("availableScreen",n,_[O],_[q]),wn(w,n,tn(t[X]||0,t[M]||0,e[x]||0,e[X]||0,e[M]||0),tn(t[Y]||0,t[W]||0,e[z]||0,e[Y]||0,e[W]||0)),wn(D,n,_.width,_.height),wn("viewport",n,Q[H],Q[K]),n}(),o=function(){var n={scrollCounts:a,reachedDepth:u,horizontalScrollDistance:f,dwellTime:s,vScrollDirChanges:l};return"number"==typeof c&&(n.clientTimeToFirstScroll=c),n}();e?sn=0:(mn(),rn=R(),t&&(r=rn)),L("log",{activity:o,dimensions:i,schemaId:"<ns>.PageInteractionsSummary.3"},{ent:{page:["pageType","subPageType","requestId"]}})}}function Pn(){Tn(),In(fn)}function Dn(n,e){return function(){cn=e,n()}}function Cn(){an=function(){return cn},cn&&!r&&(r=R())}"function"!=typeof Z[y]||J||(mn(),v&&vn(),U(Q,C,Sn,{passive:!0}),U(Q,"blur",Pn),U(Q,"focus",Dn($n,1)),V(S+"android",Cn),V(S+"ios",Cn),U(S+"pause",Dn(Pn,0)),U(S+"resume",Dn($n,1)),U(S+"resign",Dn(Pn,0)),U(S+"active",Dn($n,1)),an()&&(r=rn||R()),V("$beforeunload",In),U("$beforeunload",In),U("$document.hidden",Pn),U("$beforePageTransition",In),U("$afterPageTransition",function(){sn=N=1}))});csa.plugin(function(e){var o,n,r="Navigator",a="<ns>."+r+".5",i=e.global,c=e.config,d=i.navigator||{},t=d.connection||{},l=i.Math.round,u=e("Events",{producerId:"csa",lob:c.lob||"0"});function v(){o={network:{downlink:void 0,downlinkMax:void 0,rtt:void 0,type:void 0,effectiveType:void 0,saveData:void 0},language:void 0,doNotTrack:void 0,hardwareConcurrency:void 0,deviceMemory:void 0,cookieEnabled:void 0,webdriver:void 0},w(),o.language=d.language||null,o.doNotTrack=function(){switch(d.doNotTrack){case"1":return"enabled";case"0":return"disabled";case"unspecified":return d.doNotTrack;default:return null}}(),o.hardwareConcurrency="hardwareConcurrency"in d?l(d.hardwareConcurrency||0):null,o.deviceMemory="deviceMemory"in d?l(d.deviceMemory||0):null,o.cookieEnabled="cookieEnabled"in d?d.cookieEnabled:null,o.webdriver="webdriver"in d?d.webdriver:null}function k(){u("log",{network:(n={},Object.keys(o.network).forEach(function(e){n[e]=o.network[e]+""}),n),language:o.language,doNotTrack:o.doNotTrack,hardwareConcurrency:o.hardwareConcurrency,deviceMemory:o.deviceMemory,cookieEnabled:o.cookieEnabled,webdriver:o.webdriver,schemaId:a},{ent:{page:["pageType","subPageType","requestId"]}})}function w(){!function(n){Object.keys(o.network).forEach(function(e){o.network[e]=n[e]})}({downlink:"downlink"in t?l(t.downlink||0):null,downlinkMax:"downlinkMax"in t?l(t.downlinkMax||0):null,rtt:"rtt"in t?(t.rtt||0).toFixed():null,type:t.type||null,effectiveType:t.effectiveType||null,saveData:"saveData"in t?t.saveData:null})}function f(){w(),k()}function y(){v(),k()}c["KillSwitch."+r]||(v(),k(),e.on("$afterPageTransition",y),e.on(t,"change",f))});
+if (window.ue && window.ue.uels) {
+    ue.uels("https://c.amazon-adsystem.com/bao-csm/forensics/a9-tq-forensics-incremental.min.js");
+}
+
+
+ue.exec(function(d,c){function g(e,c){e&&ue.tag(e+c);return!!e}function n(){for(var e=RegExp("^https://(.*\.(images|ssl-images|media)-amazon\.com|"+c.location.hostname+")/images/","i"),d={},h=0,k=c.performance.getEntriesByType("resource"),l=!1,b,a,m,f=0;f<k.length;f++)if(a=k[f],0<a.transferSize&&a.transferSize>=a.encodedBodySize&&(b=e.exec(String(a.name)))&&3===b.length){a:{b=a.serverTiming||[];for(a=0;a<b.length;a++)if("provider"===b[a].name){b=b[a].description;break a}b=void 0}b&&(l||(l=g(b,"_cdn_fr")),
+a=d[b]=(d[b]||0)+1,a>h&&(m=b,h=a))}g(m,"_cdn_mp")}d.ue&&"function"===typeof d.ue.tag&&c.performance&&c.location&&n()},"cdnTagging")(ue_csm,window);
+
+
+}
+(n=>{var M,A=1e6,E=(n.Symbol||{}).iterator;n.RXVM=function(r){(r=r||{}).mi&&(A=r.mi);var i=n([1,function(n){n.u.t[m(n)]=h(n)},2,function(n){n.i[0].t[m(n)]=h(n)},3,h,4,function(n){var r=h(n),t=h(n),n=h(n);w(n)&&(n[t]=r)},5,function(n){var r=h(n),t=m(n);w(r)&&"function"==typeof r[E]&&(n.u.t[t]=r[E]())},6,function(n){var r=n.u.t[m(n)],r=r&&r.next?r.next():M,t=m(n),u=x(n);w(r)&&!1===r.done?n.u.t[t]=r.value:d(n,u)},10,function(n){n.u.o.push(h(n))},11,function(n){n.u.o.push(n.v)},12,function(n){for(var r=F(n);0<r--;)n.l.push(S(n))},30,function(n){return!h(n)},42,function(){},43,function(n){for(var r=F(n);0<r--;)n.u.t.push(n._.pop())},45,a(!0),44,a(!1),48,v(0,y),49,v(1,y),50,v(2,y),51,v(-1,y),52,v(0,_),53,v(1,_),54,v(2,_),55,v(-1,_),58,function(n){d(n,x(n))},59,s(!0),60,s(!1),64,function(n){var r=x(n),t=p(n,n.u.h);return d(n,r),t},65,function(n){var r=F(n),t=x(n),u=p(n,n.u.h);n.u.t[r]=u,d(n,t)}]),o={40:function(n,r){return"__rx_cls"in n?n.__rx_cls===r.__rx_ref:n instanceof r}},t=(o[20]=Math.pow,l(16,"+"),l(17,"-"),l(18,"*"),l(19,"/"),l(21,"%"),l(22,"&"),l(23,"|"),l(24,"^"),l(25,"<<"),l(26,">>"),l(27,">>>"),l(28,"&&"),l(29,"||"),l(31,">"),l(33,">="),l(32,"<"),l(34,"<="),l(35,"=="),l(36,"==="),l(37,"!="),l(38,"!=="),l(39," in "),n([10,M,11,null,14,!0,15,!1])),u=n([1,function(n){return n.v},17,F,18,function(n){n=m(n)|m(n)<<8|m(n)<<16|m(n)<<24;return n=2147483647<n?-4294967295+n-1:n},19,function(n){for(var r=[],t=0;t<4;t++)r.push(m(n));return new Float32Array(new Uint8Array(r).buffer)[0]},12,S,13,function(n){return n.l[F(n)]},20,function(){return[]},21,function(n){for(var r=F(n),t=[];0<r--;)t.unshift(h(n));return t},24,function(n){for(var r,t,u,i=F(n),o=[];0<i--;)o.unshift((u=t=void 0,r=m(r=n),t=128&r?-1:1,u=r>>3&15,r&=7,15!=u?0==u?r/8*t*.015625:t*(1+r/8)*Math.pow(2,u-7):NaN));return o},22,function(){return{}},23,function(n){for(var r=F(n)/2,t={};0<r--;){var u=h(n);t[h(n)]=u}return t},32,function(n){return n.u.t[F(n)]},33,function(n){return n.i[0].t[F(n)]},48,function(n){var r=h(n),n=h(n);return w(n)?("function"==typeof(r=n[r])&&(r.__rx_this=n),r):n},50,function(n){return n.u.o.pop()},52,function(n){return typeof h(n)}]);function f(n){for(;0<n.p--&&(r=n).u&&r.u.h<r.m.length;){r=m(n);n.v=e(r,n)}var r}function e(n,r){var t,u;return n in o?(t=h(r),u=h(r),o[n](u,t)):n in i?i[n](r):void k("e2:"+n+":"+r.u.h)}function c(n,r){return{F:n,h:n,t:[],o:[],S:r}}function n(n){for(var r={},t=0;t<n.length;t+=2)r[n[t]]=n[t+1];return r}function a(i){return function(n){var r=i?h(n):M,t=n.i.pop(),u=M,u=t.S?t.t[0]:r;return n._=[],n.u=n.i[n.i.length-1],b(n,n.u.F),u}}function v(u,i){return function(n){var r=h(n),t=u;for(-1===u&&(t=F(n));0<t--;)n._.push(h(n));if(n.v=M,r)return i(r,n)}}function s(u){return function(n){var r=h(n),t=x(n);(u&&r||!r&&!u)&&d(n,t)}}function l(u,i){o[u]=function(n,r){var t=Function("a","b","return a"+i+"b");return(o[u]=t)(n,r)}}function _(n,r){var t;if(n.__rx_ref&&n.g===r){var u=c(n.__rx_ref,!0);u.t.push({__rx_cls:n.__rx_ref}),r.i.push(u),r.u=u,b(r,u.F)}else if("function"==typeof n){u=r._.reverse().splice(0),u=Function.prototype.bind.apply(n,[null].concat(u));try{t=new u,r._=[]}catch(n){}}else k("e5:"+n+":"+r.u.h);return t}function y(n,r){var t;if(n.__rx_ref&&n.g===r){var u=c(n.__rx_ref);u.t.push(n.__rx_this||this),r.i.push(u),r.u=u,b(r,u.F)}else if("function"==typeof n){u=r._.reverse().splice(0);try{t=n.apply(n.__rx_this||this,u),r._=[]}catch(n){}}else k("e4:"+n);return t}function h(n){var r=m(n);return 0<(128&r)?e(127&r,n):r in t?t[r]:r in u?u[r](n):void k("e3:"+r)}function p(t,u){var n=g(function(){var n=c(u),r=n.t;return r.push(this),r.push.apply(r,arguments),t.i.push(n),t.u=n,t.p=A,b(t,n.F),f(t),t.v});return n.__rx_ref=u,n.g=t,n}function w(n){if(n!==M&&null!==n)return 1;r.unsafe&&k("e10"+n)}function b(n,r){n.k=r%127+37}function d(n,r){n.u.h+=r}function m(n){return n.m[n.u.h++]^n.k}function x(n){n=m(n)|m(n)<<8;return n=32767<n?-65535+n-1:n}function F(n){for(var r,t=0,u=0,i=n.u.h;t+=(127&(r=n.m[i+u]^n.k))*Math.pow(2,7*u),u+=1,0<(128&r););return d(n,u),t}function S(n){for(var r=F(n),t="";0<r--;)t+=String.fromCharCode(m(n));return t}function g(n){return function(){try{return n.apply(this,arguments)}catch(n){k(n)}}}function k(n){if(r.unsafe)throw Error(n)}this.execute=g(function(n,r){var t,u;return 82!==n[0]&&88!==n[1]?k("e1"):(n=n,t=3,(u=c(0)).t[0]=(r=r)||{},u.h=t,b(r={m:n,p:A,v:0,i:[u],u:u,_:[],l:[],k:0},0),f(t=r),t)})}})("undefined"==typeof window?global:window);
+(n=>{for(var t="undefined"==typeof window?n:window,i=0,n="addEventListener",e="ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/".split(""),u=[],r=t.rx||{},o=r.c||{},f=o.rxp||"/rd/uedata",c=o.fi||1e3,a=1.5,d=1e4,x={},w={},m={},v={},h=0,l=0;l<e.length;l++)u[e[l]]=l;function p(n,r){return function(){try{return n.apply(this,arguments)}catch(n){s(n.message||n,n)}}}function s(n,r){if(m[i]=[(n=(""+(n||"")).substring(0,100)).length].concat((new TextEncoder).encode(n)),o.DEBUG)throw r||n;b()}function y(n,r){r=p(r),n in w||(w[n]=[]),w[n].push(r),n in x&&r()}function g(n,r){n in x||(x[n]=r,(w[n]||[]).forEach(function(n){n(r)}))}function A(n){for(var r=0,t=0,i="",o=0;o<n.length;o+=1)for(t+=8,r=r<<8|n[o];6<=t;)i+=e[r>>t-6],r&=255>>8-(t-=6);return 0<t&&(i+=e[r<<6-t]),i}function U(n){for(var r=0,t=0,i=[],o=0;o<n.length&&"="!==n[o];o+=1)for(t+=6,r=r<<6|u[n[o]];8<=t;)i.push(r>>t-8),r&=255>>8-(t-=8);return new Uint8Array(i)}function b(){!h&&0<c&&(setTimeout(p(I),c),c=Math.min(d,c*a),h=1)}function E(r){let t=[];return Object.keys(r).forEach(n=>{t.push(parseInt(n)),t=t.concat(r[n])}),t}function I(){h=0;var n=E(m);0<n.length&&rx.ep(n,T),m={}}function T(n){n=A(new Uint8Array(n));n=f+"?rid="+rx.rid+"&sid="+rx.sid+"&rx="+n;(new Image).src=n}function j(n){g("load",n)}function L(n){j(n),g("unload",n),I()}(t.rx=r).err=s,r.r=p(y),r.e=p(g),r.exec=p,r.p=p(function(n,r){g("rxm:"+n,r),m[255&n]=r,b()}),r.pc=p(function(n,r){v[255&n]=r,n=E(v),r=rx.ep4(n,rx.fnpb),n=A([rx.fnpv].concat(rx.fnpb,r)),document.cookie="rxc="+n+"; max-age=86400; path=/"}),r.ex64=p(function(r,n){y(n||"init",function(){var n;t.RXVM&&(n=U(r),t.$RX||(t.$RX=new t.RXVM({mi:o.mi})),$RX.execute(n,t))})}),r.e64=p(A),r.d64=p(U),r.erc4=p(function(){var n=rx.fnpb,r=rx.fnpv,t=rx.ep4(E(m),n);return A(new Uint8Array([r].concat(n,t)))}),g("init",{}),"complete"===document.readyState?j({}):n in t&&(t[n]("load",p(j)),t[n]("beforeunload",p(L)),t[n]("pagehide",p(L)))})(window);
+rx.ex64("UlgBKT4nV10haERRTSFMSFBJIUFKS0AgU0RJUEAjSUBLQlFNIVFNQEsvSktGSkhVSUBRQC1GRElJR0RGTidCUSBDSUpKVyFhRFFAJktKUi9wTEtRHWRXV0RcJlZAUS5wTEtRFhdkV1dEXCNHUENDQFcjVlBHUUlAIkBLRldcVVEhS0RIQCJkYHYIZmdmI0FMQkBWUSJ2bWQIFxATIGFgZ3BiIUBdQEYmV0xBJlZMQSQkFSglBSUkJ7gzFSkkRgUkJCa4FSkjRldcVVFKBSUVKS1IVmZXXFVRSgUlZCIBJa6EsbWJjtHg/fHA6+bq4eD3pIWGtYmD4Ovm6uHghLSEpYSohGQtoiUFLy8sP8HTmNsjHw8pDi8rLy0oLSo0LhweIyweIy8PLj+f3fPfJ7YOKg4sLywvFM/RLyy2HiMrDi8OLC8strU/Pg4sDiwcHiMsHiMvDy4/xbqBgSYOLC8sLy8strU/Iw4sDiwcHiMsHiMvDy4/m/LkuyIOLC8sLy8strU/Pg4sDiwDtT8uDixkLD4lETk7PgoaOBo7PgoaORo7GjgaOz4aPho5GjsWZC+bJXJbWFpNWF1NWFxIWVhfSFlYXkhZWFFIWWX5SNlbeVFIWV15UXlReVpYUclIWHlRY7+mWFFIWWX5SNlbeVF3WVhczEjZW8lpzGlUXHlbeVF5W8lpeVF5WnlcanhQWnlceVF5WlhRyUhYeVFjkKZceVhQX1BTHFlYXsxI2VvJSFh5XlhfzEjZW8lpeV55WnlfanhQWnlfeV55WmhpVV0pLCoxeV3BacxI2VvJaXlfeVppeV55WnlaeVNj76Z0eV1kLmIlt56gO7ydkZqRnK2skZq8nbyesZ2ms5ygO7ydkZu7nJi8npGUvJ3cj5xsd3ZLTmZGdkpANCM1MyoyZkZql5iukZu8nbG8nbBkKbElQ2pU9fZJbPZJbmloRFhYZWRYZWNJaHt5gG9pY1lYZWJYZWlJaFp1aVhlYVhlaEloaWtpXVhlZUlo+FhlbUhpeWxpbGldWGVnSWh9aUhra1hleGljXVhlZUloWmNZWGVmSGxaWlhlZkhseWxIaVtYZXpYZXlJa2tIbElsf2556GllbUluZGoBHmV8ZXtjWkljSGpaRGQoXCWqg4CDHKCEoYO9H6GDgIGtsbGMjbGMiqCBkpBphoCKsLGMi7GMgKCBs5yAsYyIsYyBoIGAgoC0sYyMoIERsYyEoYCQhYCFgLSxjI6ggZSAoYKCsYyRgIq0sYyMoIGzirCxjI+hhbOzsYyPoYWQhaGAs6CLoYOhhayAZCsiJFR9Tl54X35+fn5OXnhffX59fk1PcmpPcm5efF9+cml0PxZ/iaOXkq+vg6KCo6Cno5GSrqvLz9LN0Nbpx9uSr7ODoae3oK6lxsfB0NvS1q+wrbWmsyKjr6evtq+xgqOuodDD1aniv6JMZmVjR2ZbV2pwRmVrZ2NGY2tiODgCFQxGZkpGY6mQg6mQkI+jdE1edE1Nfnx+TU9yak9ybl58X31yaXQ/VH8MJhUXKyJUS05EQgcmNjc2JyUhJhsXKjAGJSsnIwYhKyJ4eEJVTgYmCgYhdE1edE1Nfnt+Q09yaF59W39OT3N8HhMTT3N4Lw0QEhYMGl5/an1fe198dHtNc3sgIBoNXn5TFBUoPQUkBSkuIRcpJ0BVBSQUFSg9BSQFKC4hFykmQFURBSQUFSg9BSQFLy4hFyknQBEFJBQVKD0FJAUtLiEXKSRNBSQZuRUoPwUkFSg8BSQxJRQVKD0FJAUrFyQVKD8FJBUoPAUk","load");
+rx.ex64("UlgBKSInV10hQUpLQCBTRElQQCNJQEtCUU0mVUpSIENJSkpXIFdKUEtBJCQVKSFAXUBGFSglBSUkJxUpIWhEUU0FJSQmFSkja1BIR0BXBSVkITklUnh4e2h5fFl4en96fXN5eHvpWX1Ze0OIhlRZe2QgNSWymKi4nbmYiqmUmrmYmLSYZCNnJQUvHw8rDi8vLC8vLT8uKw4vKigqKzkuHB4jKg8sPyy/DiwOKz4vDi0vLS8UytEfHiIqXV9cWg8svR4jLQ4vDi0DL2QiayVfdXV2RHl3VHVFVXFUdXV3dUVVclR1dXB1RUR5cVV2VHZiZYuLd3V/RUR5cVV2VHdiZYuLd3V/RUR5cVV2VHBiZYuLd3V/d2F3RkZGWXVkLWUlbEZ2ZkBnRkZFRmpSQdFWuEZ3VkVnRd1WT3dWRWdF0Va4RndWRmdF3VZPd1ZGZ0XRVrhGd1ZHZ0XdVk93VkdnRWQs1SWgirq7h4Pi+M3i5eL/7qqIq4qVipaKLYeN5f7m6e75v6uKgLq7h47i+MXqxaqIq4qAlrm5t4qDi6aeiZp3ipqLiomai7crmourioaLiomaCwuJiooaq4qai7cvmourioyLpp6Jmouai7q7h4/n5Oy5qomrioC6u4aOqom5ioiKubuGj6qJq4iaiZiKq4qamoqKmZoLg4qAuruGjaqJuYqPioqIG5qEq4i3KZqLq4iui7m7ho+qiZl5dHR0momYiquKmZoLg4qAuruGjaqJuYqPioqImouKjhyrjxwSmoGriKuJpp6JEZqDq44dmnSKq45kL6glqoCAgxaxkIGhgBiQibGQgKGAgIKQgL0XkAEBg6GDhoGAgpN+fn5+gIUXkJ4bkIuhg4CEF5B+hqGDvSWQnqGFiIGssY2Cz+DPoIK9JZCBoYWcgbOxjIWgg5Nzfn5+kIOTgBMSkAGJoYShgqyAu5yBs7GMhaCDEJCOoYWQg5OAExESkAGJoYSQgKGCrICtFAUkBSIuIRcpJ1ZEFSglBSUUBSQFLS4hFykmVkRHFSglBSUUBSQFLC4hFykhQEMUExUoJQUlFAUkBS8uIRcpIUFDFBMVKCUFJRQFJAUhLiEXKSFEVlBIFSglBSUUBSQFIC4hFykhRERTQhUoJQUlFAUkBSMuIRcpIURWUUEVKCUFJQ==","load");
+rx.ex64("UlgBKSQnV10kJCkjGWtqa2AbJCc0JWQmbyUVPj4zPz4+r6IePg8zNkpMWk1+WFpRS6IpDzM2UV5JVlheS1BNHj8fPj4+r6IePg8zPExWWw8yPx4/Hz4ODzM+Vw8yPx4/Hz4SPhQVKSFAXUBGFSglBSUFJhUkJCEkIQUhKSZDS1UVKCUFJSEwIbM02iQFIbM02iS+NC0FIbM02iS+NDUFIbM02iS+ND0FISkhQ0tVRxUoJQUlIQUnKSFDS1VTFSglBSU=","load");
+rx.ex64("UlgBKSwnV10hQF1ARiBWSUxGQCdAESRVJEInVlMnTEEmV0xBJCQVKCUFJSQnFSkhb3ZqawUlJCYVKSlJSkZESXZRSldEQkAFJSQhNCAkICglJCMVKSFDS1VTBSQkIhUpIUNLVUcFJGQtuyW60BSQvpWVpLWRtZeoMp60leCUpaSYl/CioLWVtJWVlpWmpJmWtJaFkYWVlZeVpaSZlrSWhZGfpqSZl7WVtJemlZCVoaSYnsH9+uCs1ebm9e21lLSQn6CkmJ/A8ezg0PH3+/Dx5rWUl6SYkvDx9/vw8ZWllaaVkZWlpJiR5PXm5/G1lrSRuZW4m6GgnZGxkaKgkY2HlIadlYSdlJG9kWQsUCUfNQUEOD1HQEZdWlNdUk0VNhQ1NTY1AAQ4P2BRTEBxWldbUFFGFTQ3BDgyUVpXW1BRNQU1FDY/BgQ5NxU1FTMGNTc1BgQ4MldbWldVQCE1FTIUNxUzPwUEODdRAgAVNQY/MAYVMRU3MKQlNQQ5MhU1OTIVNRhkL6clBSweDyYvLS8vKiUrHiMqDi0rKCsoNi4Sih4jJg8vHiMpDigpLi8qDigULS4UzdESiiUOKhEuLyo5LB4jJg8vIykfHiIqXltdRh4jKg4tDioSsQ8qHiIoQktASVpGHiMqDi0/Lh4eIitdRkdIWh4jKg4tFPXRKg4sDi8OKh8PJw4tAmQuPSUeNwUUPTQ2NDEVNxU0BTgwFTYEFDwVNhkhNCUoIwUkFBUoJAUkBS8uIRcpJlZVQQUkFBUoJAUkBS4uIRcpJlZCQQUkFBUoJAUkBS0uIRcpJ0JBBSQ=","load");
+rx.ex64("UlgBKS8sUkBHQVdMU0BXI2pHT0BGUSFOQFxWIkxLQUBdakMhQUpLQCBTRElQQCBkV1dEXCN2XEhHSkkgdVdKXVwnV10kJDQ1JCc0JCQmuDMVKSxLRFNMQkRRSlcFJSQhuDMVKS1BSkZQSEBLUQUlZCA2JbK1BgaolJLo9Pnh7+rx//DsuZhkIyglGh2tlxEwPTAAPTARM2QiCiVrcHFMQ3FMQGBBYEFEQEBHQENYQXBxTEJhQ01FIiUiHmVQQUB9QENBbE97o75sTmQtuyVeRUR5dkR5dVV0VXRxdXVydXb8dEVEeXdUdnhyKzUGBhUNVWV0dWh10nlyVHZo0ER5clV0RFR2VXR1SHV2dFl6RUR5d1R2eHMrJw0ZFhsYVWV0dWh10nlzVHZo0ER5c1V0RFR2VXR1SHV2dFl6RUR5d1R2eHIrJAYbDA1VZXR1aHXSeXxUdmjQRHl8VXREVHZVdHVIdXZ0WXpOB4tZe2QsBSW9ugowtpebnPT2+/vH//b54/j6MLaXm5/I5//2+eP4+mQv5iUWDQwwMV9OWV1IWXlQWVFZUkgdODA6X11SSl1PPT09DQwwNltZSH9TUkhZREgcPTA5S1leW1A9Pj0Aohw+PjwRMg0MMDBbWUh5REhZUk9VU1IcPjAla3l+e3BjWFleSVtjTllSWFlOWU5jVVJaUz8MMCtpcnF9b3d5eGNueXJ4eW55bmNreX57cD03DQwwMFtZSGxdTl1RWUhZThw+Dj0/PQCYNhw/PjwRMg0MMT8cPzA3b0tVWkhvVF1YWU4dLTw9ET1kLgYlrqkgtIiP7erq4fbM4e3j7PClhLSIj+vx8OH2zOHt4+zwpYRkKQ4lBgGIHCAmRUJCSV57RUhYRA0sHCAnT0BFSUJYe0VIWESxOhwgKE5DSFUNKCQoMC0FKQUuBS8FLAUtBSIFIwUgZCt5JUVubn5vbm1+b2pOYmxpbGtYb15fY2sKFwoMX2JmTm9Pa19ubmpuU8tlT2psb25qYVNPamVvbm749k9tfm5Pbm5t/35uT21Vq5BdX2NuH19iZk5vem1Pbk5tTm5DFxUpJFcVKCwFJQUrKSFJSkRB","load");
+rx.ex64("UlgBKS8mVlVBNURBQWBTQEtRaUxWUUBLQFcsSEpQVkBBSlJLIkhKUFZAUFUhQF1ARjZXQEhKU0BgU0BLUWlMVlFAS0BXLFFMSEB2UURIVS5VQFdDSldIREtGQCZLSlIkVyQkNAUkJzQqJCYyISspIkZEVVFQV0ArKSJVRFZWTFNAJCE0zSIkILgzFSktQUpGUEhAS1EFJSQjFSkhaERRTQUlJCIVKSdXXQUlJC0VKS5WQFFsS1FAV1NESQUlJCwVKShGSUBEV2xLUUBXU0RJBSUkLyskLiokKjQlJDQxZDcBJaK0FRapgxapgomIpIqDh7m4hIr76amPqZmDuriFiKmPuqmJpGQ2EyUbAgE8MBA0MhAyED08MwIBPDAQNDIQMhA8PDINATwxEDYjMQABPDUQNhAjOgMQORA1AzM/MB1kMQElQWlhZFhbZm5KbmhKaEpnZmlYW2ZuSm5oSmhKZmZoWkpiSmVHZDAAJbmvDbKZkpO/kZmcoqOfkODy8bKUsoKSkpKho5+S47KUs5Kykr9kMzMlFjwNDTA1DTA6HD0gPA0wOx08Py08EWQyYSV8VmdnWl9nWlB2V0pWZ1pRd1ZWVVZWVMZ2R3dVVVjHRlZ2WFVcWWZnW1MnIiQ/dkZ3VGv2dlV2WF5XZ3ZCZ3ZFZ3ZDexQVKCEFIgUzJCkkFBUoIQUiBTIkKCQXFSgsBSIFNikhSUpEQRcVKCwFIgUwKSNQS0lKREE=","load");
+rx.ex64("UlgBKS8mVlVBJ1ZEI0ZKS0ZEUSxISlBWQEhKU0AhQF1ARiZWREchRkBMSSFVUFZNJkRHViRXJCQ0BCQnNO0kJCY02iQkITIhKykiRkRVUVBXQCspIlVEVlZMU0AkIDTNIiQjuDMVKS1BSkZQSEBLUQUlJCIVKSFoRFFNBSUkLRUpJ1ddBSUkLBUpLlZAUWxLUUBXU0RJBSUkLxUpKEZJQERXbEtRQFdTREkFJSQoKyQrKiQ2NCUkMTEkMDFkMxYlTFr7+Edo+EdrZ2ZKZGhpV1ZrZ0duR3NtV1ZrZ0duR3JlVmtkZ1dnVG1UVmtmR25UR2dKZDIcJbeurZGN/Pn52Ov48+nR9O7p+PP477ybnryZvJaQnqGtkJ28lY+drK2QmbyVvIuWr7yUvJivn5GcsWQ9DyVxWVZUaGtXSCk+NjQtPh4tPjUvFzIoLz41Pil6XVh6X3pQVlhqelF6V3dkPBAlo7UXqISIiaWLhIa4uYSMqIGonYiIiLi5hIyogaicgri5hIupiLuIiIi7uYWI+aiBqYioiKVkP3okaEJzc09ALSw0c09IMyYxJSwxLiItICZiQ15Cc09KNyouJhA3Ii4zY0JCQUJCQN5SQ3NPRjMiJCYbY0JCR95SQ3NPRjMiJCYaY0J/3+diUmNH52JTY0BCQ29/39xiQdJiTGNBYkxPQ0FMSUFTSUFSSUFRSX/lSWJMN0Nxc09GIjciLXFiRNJiU2NA0mJSY0dCRkJyc09HMDIxN2JE09dSQdJjQGJT11JB0mNHYlJIcnNORWJEcUJFQn/e52JMY0HnUkNjRUhDcnNORGJXUkN5XkNyc05FYkTRUqtE0NJiTGNBY0VCREJyc05EYldjRH/lSWJRfUNyc05LYkTSYlFjRlJC0XNPQRMKYkRSQUhyc05LYkTSYlFjRkhxc09ALiotYkRxcUJLQnJzTkRiVtFSq0RjS0FQ01JCYlBBTGNBQVNjQEFSY0dBUWNGQU1Nf9xiQGJQSkNzYlpzYlVzYltvFBUoIQUtBT8kLiQXFSgsBS0FMikhSUpEQRcVKCwFLQU8KSNQS0lKREE=","load");
+rx.ex64("UlgBKSAnV10mVlVBI1ZGV0pJSSFAXUBGJFckJDQHJCc07SQkJjTaJCQhMiErKSJGRFVRUFdAKykiVURWVkxTQCQgNM0iJCMVKSFoRFFNBSUkIhUoJQUlJC0VKS5WQFFsS1FAV1NESQUlJCwVKShGSUBEV2xLUUBXU0RJBSUkLyskKCokNDQlJDcxZDYCJR4IqaoVOaoVPjU0GDY5OwUEODZHVQQ5NBU0FSY/BgQ5NRUzBhU1GGQxHCV1bG9TTz47OxopOjErEzYsKzoxOi1+X1x+W35UUl1jb1JeflhNX25vUlx+WH5MVG1+V35abV1TXnNkMA8ltp6Wk6+skI/u+fHz6vnZ6vny6ND17+j58vnuvZyfvZi9l5Gerb2VvZCwZDMOJWF31WpBSktnSUFEentHSDgqKXtGS2pLallKSkp5e0dKO3tGS2pLa0pqSmdkMpAlUXtKSnZ5FBUNSnZxCh8IHBUIFxsUGR9bemd7SnZzDhMXHykOGxcKWnt7eHt7eedrekp2fQkZCBUWFiNbekbm5Vt461t0WnhbdHN6eHRweHVweGpwRtxwW3RMektKdnkbGAlbfOtbdVp5e357S0p2fhkfExZbfOhrkn3p61t0Wnhafnt/e0tKdn4KDwkSW2haf3hr6mt7W2t4dFp4eHVaeXh3dEblW3lba3N6SltsSltpSltvVhQVKCYVKCUFJQUyJC4kFxUoIRUoJQUlBTEpIUlKREEXFSghFSglBSUFMykjUEtJSkRB","load");
+rx.ex64("UlgBKSQnV10kJDQGJCcpI1ddCFVLUSQmNP0hJCEVKCUFJSQgFSkpSUpGREl2UUpXREJABSVkI4oldF9fyU9ezU+2WW5SUTA/KDc5Pyo3MTANKj8sKsNIblJYKjczNzA5w0huUlUuOyw4MSwzPzA9O39eX1xuf1x/W19dVWL4VH5cdV5vblJWLj8sLTsXMCp/Xn5cT19+X1VsblJdMz8mblJaEz8qNn9eT15sX11fYv9/XX5dXV5fXVVafl9/XH9bbG5SXS0uOn9afl1/X29uUlo7OG9oblNef15+XVVsblJfLn9abH9fchcVKSRXBSEFIykhSUpEQQ==","load");
+rx.ex64("UlgBKSQnV10kJDQVJCcVKSFAQxQTFSglBSVkJr4laUJC3lVzT0UwIDEmJi1iQ0JBc09GNConNytjQkJAc09FKyYqJCs3Y0JCR3NPSSotLSYxFConNytiQ0JGc09IKi0tJjELJiokKzdiQ3FzT0AwJCdzTkNiQ1ZHY0ZjR2NAY0FiQnJiQWNBSHJiQWNASHJiQWNHSHJiQWNGSHBzT0UgLC0gIjdXR3FxcXFIcXNPQjNzTkNiQ3FiQm8XFSkkVxUoJQUlBSYpIUlKREE=","load");
+(i=>{let n=i.Math;function e(){for(let t=0;t<this.length;t+=1)this[t]=n.max(0,this[t])}function o(){for(let t=0;t<this.length;t+=1)this[t]=1/(1+n.exp(0-this[t]))}function r(t,n){var r=new i.Float32Array(t*n);return r.rows=t,r.columns=n,r.R=e,r.S=o,r}i.rx.M=function(t,n,r){return t.rows=n,t.columns=r,t.R=e,t.S=o,t},i.rx.M.zero=r,i.rx.M.mul=function(e,o,t){var n=e.rows,f=e.columns,u=o.columns,l=r(n,u);for(let i=0;i<n;i+=1)for(let r=0;r<u;r+=1){let n=t[r];for(let t=0;t<f;t+=1)n+=e[i*f+t]*o[t*u+r];l[i*u+r]=n}return l}})(window);
+rx.ex64("UlgBKTcnV10kaCJSQExCTVFWI0lAS0JRTSFHTERWIkNKV1JEV0EgQkRISEQgVklMRkAhR0BRRCFIQERLLVNEV0xES0ZAIkBVVkxJSkspQ0BEUVBXQGtKV0hWI0lEXEBXViFBSktAIFNESVBAIVFcVUAhVVBWTSQkFSkhaERRTQUlJCcVKCUFJSQmuDMVKSRGBSckIRUoJBUoJQUlZCBnJW1FdWdCRXZLRWZEZkVmR01CdEtEZkZCZkRLQmZGBlxGTWdVVmplCxMKR2JlVmtiRmZWa2RGZkZnS2dNQnRLQ2ZGamQj4iWnj768gYusjayOnYyHiL6BiqyMvryBi6yNHp2OrI6sjoeIvoGErIy+vIGLrI0enY+sjh6djqyOh4i+gYWsjL68gYusjR6diKyOHp2PrI6HiL6BhqyMiKyPgYesjMzsjEdtbW59bFDMXGFvTG1MbiBsXVxgaB8dHhhNbfxcYWdMbFxMblxhZkxsf23+/VxMblxhZUxsXExuTG1cTG5cYWpMbHxcTG5cYWRMbG1naF5MbkxtbW78fW1MblbFk0FMbYeIvoGJrIygZCI9JXMZVVl2XG1tUVwPfVxwfVxSXWtUXHlZdWQtPSVfNXl1UnhJSXV4Kll4VFl4fnFHeHBVdVlkLMUlupOVsZCcnbGRlbGTnJyxkdFUkQ4kJCc0JRmFFSgmBSQFJ6IlFxUoIhUoKQUltTQgtzQgBSe3NCAFJyQmJBQVKS1MVmNMS0xRQBUpI2tQSEdAVwQlFQUnBSQ7JBkkLyUhFTQlBSYFJwUkFxUpJkhMSwQkFQUnBSQVNCcFJi4XFSkmSERdBCQXFTQkBSY0FTQmBSYkNhU0IQUmJC4hFwUnBSQkJ7U0JAUnH0vaFgQhJhUoJgUkNCQFJCQkJCAVKCgFJSEjISArJRQVKCAFIAUkJCQkH8jaCAUkmpWjnJSxkb1kL/IlXHZ2dWNGR3tyERsYGAVWduRmckd6dEd6e1d2dnR2ckd6eld2c3FzctZ3S9N7chMSGQQSR3pnV3JSd0BWcnRXdEd6c1dyR3p1V3J8Rkd6Zld1RXZ0R3p0R3pzV3JNHndL03t+FRYDFB8ZGAUaR3pnV3Jsd0BWcXRHenxXcld0R3p1V3J8Rkd6Zld1RU1Nd0vTe3MFEhsCR3pnV3J5d0NWcHxGR3pmV3VFTWp3S9N7cAQeEBoYHhNHemdXcnx3Q1Z/fEZHemZXdUVNLYhBVn5XdUd6e1d2WnYhBSEoJAUnIQUsKSdoaQUnIQUvKSBWVUBGVgUsGRUpIGFgZ3BiBSYQJSEFICkgYUBLVkAFLCEFIyksZ0RRRk1rSldIBSwhBSIpIXdAaXAFLCEFLSkidkxCSEpMQQUs","load");
+rx.ex64("UlgBKSokVSFBSktAIFNESVBAI0lAS0JRTSdMQS1DQERRUFdAViBISkFASSFRXFVAIEFAS1ZAIlJATEJNUVYhR0xEVixHRFFGTUtKV0giQFVWTElKSyFXQElQJ1ZTJCQVKSdXXQUlJCcVKSFEVlFBBSQkJhUpJEYFJCQhFSkhRERTQgUkJCAVKS1MVmNMS0xRQBUpI2tQSEdAVwUlJCM0ZSQiNOktJC0uZCxpJXlRU1ZGU1diX1JyU1dyV1RUVFViUldyUFpUWltdUm5yVVVSU1VicltyVWi+rWNzV3JVblNeUmNiXlYiJyE6clZyVWiZrWNyUXJWf1NkLw8liaOjoLOip4KjoaShprCingazooKmpaKjoDKzo4KgmEtdjzGSr6GCo4KgZUgke1FRUs1EYEFgYFxRN3BRY3FZU3FURVFBc3BRW2NxWVNxUkVRQXNwUVtjcVlTcVRFUkFQQXBwUVtjcVlTcVRFUkFRQXBwUVtjcVlTcVRFUkFSQXBwUVtjcVlTcVpFUkFQQXBwUVtjcVlTcVRFUkFQQXFwUVtjcVlTcVRFUkFRQXFwUVtjcVlTcVRFUkFSQXFwUVtjcVlTcVpFUkFQQXFwUVtjcVlTcVRFUkFTQXFwUVtjcVlTcVRFUkFUQXFwUVtjcVlTcVRFUkFVQXFwUVtjcVlTcVpFUkFTQXFwUVtjcVlTcVRFUkFQQXJwUVtjcVlTcVRFUkFRQXJwUVtjcVlTcVRFUkFSQXJwUVtjcVlTcVpFUkFQQXJwUVtTRUpiYmJiYmJiYmJiYmJiYmJiw2BBU3BSYEFScFLDYEFRcFJgQVNwUsNgQVBwUmBBUnBSYEFTcFJgQVJwUmBBUXBSYEFQcFJiYmBdU2BdUHBRfVEuFBUpIFZVQEZWFSknaGkFJDIhMC0yJykiVkxCSEpMQSgiMiM9JDooLz0tExOSEZ+aE58oLCgtKCIyJygoKCIyIzZKN6YfKCk9BSQkJCQnJCQnDTduAHd1OHWXlh2RoruXDxISGB1hZxJlKCwoLigiMiM9LQ85bg13dQd1KC89pSQuLqYupKQupK6pIKknJK4mICCgIK+vIKIlJaMlrqwlqaioIqgnJKgmICCiIK+jIKysrCKsISesICMjoCOioCOjpSWtpauhJaqlpSUlJaWlpaytJq0ksa0nq6oiqyYkqyElJaAlqKIlr6yvIq8hJ6whp6evpquqpqwgIaAhoq8hoigsKC0oIjInKCgoIjIjNko3ph8oKT1lJicnJycmJycmJScnJiEkJCG0JaemITmvqiUhvyq3NqOCrZQGooi6i4SUi70Hj42PE2QSFGQTZBIWFxJlFRoUFygsKC4oIjIjPTUgtCWmpyA5rKolIb8qtDagKC89hSanpSekpSekJKQlJKampKUhJaUlJyWkJaQmJSelJKGnp6eloaSlp6WnpCUnJKepJScnJKQiJCEkICilsSQrqaQlpKwkLaChrSKnJSSgpCMuqqWkpqMnIySkpKUnJKGhrCQkoycipqyhLyUlJKelIzWgtKQioaWqp6OnJSYkJigusCSvp6CjIayiJCUkoCauriekpCQipS4lJCKlpyUsJacmJKckNKelpqQ1pbGlKiY3pzUkoyYnNCUjpaWlpyWorjKnrKSnrKeipSUlJ6Knq6QhpScgpyanJqSmJacnpCMvpyWjoiWjJKAlJyUnoSestSCkqCcht6WuJCQlJLMntCekICW1qiWooawxJSKlNqC0NKQkpqalpySgJiUnpCchpaUnJCMnJKAkpSYlpyQnpSahoaSkoqUlpCSupSclp6ynLSWkpCqkKycioCWiJKwtIqIhJyGkJKSlJy4lpCUuIKUlrKaipKeup6qiJSSnrqGkryMlJiQlJqQjJSWnJCanJKWrJSalpaAnoiKlp6WkJaSkPKUrJqUyJzKjJaSlJqSiNSgsKC0oIikjSURcQFdWMKckNojqIxs2MZ44GDQkNCU0JDYNY5pmNoZkLmY0uzQ0JTQlNpk9jmY2/AXbZzSvKjQlNCU2SrasZzYUWsdkNNkkNCU0JTYlyD0bNoHNaxg0JDQlNCQ2JmqQZja01vJnNI0qNCU0JTaVja5mNpiwjGc0/y40JTQlNnzzYmc2uIJKZDTWJDQlNCU2M4k8GzZm6HUYNCQ0JTQkNnhKJWY2b2MDZzSeITQlNCU2M7WIZzb5CPpkNL8mNCU0JTbo1RlnNriLRGQ0zSQ0JTQlNteV9Rg2HZyQGTQkNCU0JDYbUApnNgk1+2U0xyc0JTQlNq45U2c2hSyhZDS6JjQlNCU2DKIpZTYDQDoaNCo0JTQlNhWfkRs2ewSEGjb3VChlNh0RJxo2ewSEGjZYvzsYNhhYcRo0JDbGzBUaNhhYcRo2VOFuGDb1QlgaNiUlhRo2Q0MbGjb1QlgaNiZcsmc2WnsaYTTFLTSJITZaexphNju9vGY2fQxSYTSlKjTNJzZ9DFJhNrrEv2c2VLBDYTSlLzSTIDZUsENhNnbUh2Y2hMhYYTSlKjTNJzaEyFhhNpoLVmc2upNGZzabsyJmNgvcwRs2m7MiZjbv+ERnNhGwYWc0oiQ0JTSiJDbfNf4aNtgPV2U0IDQkNCUpKUNARFFQV0BrSldIVi4mMiMXKCMXKCA0JSghLiYwJBckLiRkKbclVkDYTHFyXX1ddH18UH50THFyXX1MTHB+GxhdfX19fX1+aX1McX9dd3ldd396f3g2fE1McXlceFx9fXl9TUxwexoTDgsdDhhMcXpceFx5fXp9TUxweBkaTUpdfUxtfFx6d05McHofExIfHQhcfk5pfUxxeFx4fX59Rs2DTkxxfF19XH5dek5McH4MH119XH5delBkKDIluaGjn5jg9ufa/ef24eXy/7KTspSyn78XFSkkVwUkBSgpIUlKREEZFSkgYWBncGIFJiglIQUuKSN6ekhBSVYFJA==","load");
+rx.ex64("UlgBKSghaERRTTZXQEhKU0BgU0BLUWlMVlFAS0BXLEhKUFZASEpTQCBGSUxGTiNWRldKSUkmUURCJ1ddIEZKUEtRIkZJTEBLUX0iRklMQEtRfCJWRldKSUl8IUBdQEY1REFBYFNAS1FpTFZRQEtAVyQkuDMVKS1BSkZQSEBLUQUlJCe4MxUpJ1BABSUkJhUpJlBAXQUlJCEVKSFWVFdRFSglBSUkIBUpJlVKUhUoJQUlJCMVKSZER1YVKCUFJSQiMiErKSJVRFZWTFNAKykiRkRVUVBXQCQtNEEkLDRBJC8uJC4uJCkuJCguJCsuJCouJDU0JSQ0NCVkNwwliJGSr6ODoqGDpYOor6CRkq+jg6Khg6WDqa+hkZKvo4OioYOlg66vpo5kNkAlemxgXVVxUmVQYWBdVXFSXEY4MSN9IyQiPz43fTk+JDUiMTMkOT8+bMxxU2BcUzkjPHFSWVBicVNdVlxSMSRsYF1XcVJLUGJgXVdxUkFRXEEDJCI/PjcZPiQ1IjEzJDk/PmBxQnxkMT8lETsGpqUrOgo3Mxo7pSs6CjcyGjs5OgobKRZkMHMlc1lkxP5TeVb+U3lVdlhqeV1JWsl5VWhVUHhZU2p5XUlayXlWaFVReFlTSGpqU2l5XGpZWllaSch4WnlJZPl5UHlJW1hoeUtaVWhVUHhZWlZoVVF4WXRkMwslGDIPlTgSPCEzAhI1ohI8Az45EjMjMhIjMSMyD5ISOhIjMDMDEiAxPAM+ORIzH2QydiVPVFVoblVoY0RlRHBnb2RUVWhuVWhjRGVEcWduZFRVaG5VaGNEZURzZ2lkVlVoaURlZkRiRG9oZ1ZVaGlEZWZEYkRuaGZWVWhpRGVmRGJEaWhhSRcVKSRXFSgjBSUFMikhSUpEQQ==","load");
+rx.ex64("UlgBKScmUURCJ1ddJCS4MxUpLUFKRlBIQEtRBSUkJ7gzFSknUEAFJSQmFSkmUEBdBSVkIWolcFpua1ddCT48HiMrelvLV1NmcwAFYAZwcst7WldecwUne3JQamtXXjY6Lzgza1ddODQ0MDI+elppWllaa2tXXy8pMjZrSll7WUdae1l2WmQgGiUELhMfIi8OLRsvHh8iLw4tvw8uIz1dVwJHRkhHSlxbAk5MW0ZAQRUTsw4sHyMsRlxDDi0mLx0OLCIuIy1OWwNkI3clWENTdn9zc3NzQ0J+dwECHhsGUnN+czJxQmNzc25zUnNzcHNOUnBbckNCfnYTBh0QU3JScHNxc0NCfngRGhMAMR0WFzMGUnFjcnN2c0NTd1J2XhcVKSRXFSgkBSUFIykhSUpEQQ==","load");
+/* ◬ */
+</script>
+
+</div>
+
+<noscript>
+    <img height="1" width="1" style='display:none;visibility:hidden;' src='//fls-na.amazon.ca/1/batch/1/OP/A2EUQ1WTGCTBG2:133-7199711-5876416:D32ZY1PB3E90Y6D0E1G7$uedata=s:%2Frd%2Fuedata%3Fnoscript%26id%3DD32ZY1PB3E90Y6D0E1G7:0' alt=""/>
+</noscript>
+
+<script>window.ue && ue.count && ue.count('CSMLibrarySize', 87501)</script>
+<!-- sp:end-feature:csm:body-close -->
+</div></body></html>
+<!--       _
+       .__(.)< (MEOW)
+        \___)   
+ ~~~~~~~~~~~~~~~~~~-->
+<!-- sp:eh:tH49I2/JELwpftG7cIDsTzZfbETdHDrj0cEEeiSnsUr3IdF0XMr9UKh4Gv1SqAccMhyFVo1idLiL8PWKDAaoRFh/MT+voImFPeahk1FCQehpH9+vYieb+o1vojY= -->

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -29,12 +29,15 @@ class TestCli(UnitTestCase):
         self.assertTrue("Usage: " in response.output)
 
     @responses.activate
-    def test_history_command(self):
+    @patch("amazonorders.transactions.datetime", wraps=datetime)
+    def test_history_command(self, mock_get_today: Mock):
         # GIVEN
-        year = 2023
-        start_index = 10
+        mock_get_today.date.today.return_value = datetime.date(2024, 10, 11)
+        year = 2024
+        start_index = 0
         self.given_login_responses_success()
         resp = self.given_order_history_exists(year, start_index)
+        self.given_transactions_exists()
 
         # WHEN
         response = self.runner.invoke(amazon_orders_cli,
@@ -47,16 +50,9 @@ class TestCli(UnitTestCase):
         self.assertEqual(0, response.exit_code)
         self.assert_login_responses_success()
         self.assertEqual(1, resp.call_count)
-        self.assertIn("Order #112-0069846-3887437", response.output)
-        self.assertIn("Order #113-1909885-6198667", response.output)
-        self.assertIn("Order #112-4188066-0547448", response.output)
-        self.assertIn("Order #112-9685975-5907428", response.output)
-        self.assertIn("Order #112-1544475-9165068", response.output)
-        self.assertIn("Order #112-9858173-0430628", response.output)
-        self.assertIn("Order #112-3899501-4971443", response.output)
-        self.assertIn("Order #112-2545298-6805068", response.output)
-        self.assertIn("Order #113-4970960-6452217", response.output)
-        self.assertIn("Order #112-9733602-9062669", response.output)
+        self.assertIn("Order #112-5939971-8962610", response.output)
+        self.assertIn("Order #112-3319487-8015418", response.output)
+        self.assertIn("Order #112-4482432-2955442", response.output)
 
     @responses.activate
     def test_order_command(self):
@@ -139,12 +135,15 @@ class TestCli(UnitTestCase):
             self.assertIn("max_auth_attempts: 7", f.read())
 
     @responses.activate
-    def test_history_command_download_invoices(self):
+    @patch("amazonorders.transactions.datetime", wraps=datetime)
+    def test_history_command_download_invoices(self, mock_get_today: Mock):
         # GIVEN
+        mock_get_today.date.today.return_value = datetime.date(2024, 10, 11)
         year = 2024
         order_id = "112-5939971-8962610"
         self.given_login_responses_success()
         self.given_order_history_exists(year)
+        self.given_transactions_exists()
         with open(
             os.path.join(self.RESOURCES_DIR, "orders", f"order-details-{order_id}.html"),
             "r",
@@ -196,4 +195,57 @@ class TestCli(UnitTestCase):
             # THEN
             self.assertEqual(0, response.exit_code)
             expected = "AmazonInvoice_20241101_112-5939971-8962610.pdf"
+            self.assertTrue(os.path.exists(expected))
+
+    @responses.activate
+    @patch("amazonorders.transactions.datetime", wraps=datetime)
+    def test_transactions_command_full_details_csv_invoices(self, mock_get_today: Mock):
+        # GIVEN
+        mock_get_today.date.today.return_value = datetime.date(2024, 10, 11)
+        days = 1
+        order_id = "123-4567890-1234567"
+        self.given_login_responses_success()
+        self.given_transactions_exists()
+        self.given_any_order_details_exists("order-details-112-5939971-8962610.html")
+        pdf_link = "/documents/download/abc123/invoice.pdf"
+        responses.add(
+            responses.GET,
+            f"{self.test_config.constants.ORDER_INVOICE_MENU_URL}?orderId={order_id}",
+            body=f"<a href='{pdf_link}'>Invoice 1</a>",
+            status=200,
+        )
+        responses.add(
+            responses.GET,
+            f"{self.test_config.constants.BASE_URL}{pdf_link}",
+            body=b"PDFDATA",
+            status=200,
+            content_type="application/pdf",
+        )
+
+        # WHEN
+        with self.runner.isolated_filesystem():
+            response = self.runner.invoke(
+                amazon_orders_cli,
+                [
+                    "--config-path",
+                    self.test_config.config_path,
+                    "--username",
+                    "some-username",
+                    "--password",
+                    "some-password",
+                    "--output-dir",
+                    ".",
+                    "transactions",
+                    "--days",
+                    days,
+                    "--full-details",
+                    "--csv",
+                    "--invoices",
+                ],
+            )
+
+            # THEN
+            self.assertEqual(0, response.exit_code)
+            self.assertTrue(os.path.exists("transactions-1.csv"))
+            expected = "AmazonInvoice_20241101_123-4567890-1234567.pdf"
             self.assertTrue(os.path.exists(expected))

--- a/tests/test_orders.py
+++ b/tests/test_orders.py
@@ -429,6 +429,33 @@ class TestOrders(UnitTestCase):
         self.assertEqual(1, resp1.call_count)
 
     @responses.activate
+    def test_get_order_2024_digital_order_rd(self):
+        # GIVEN
+        self.amazon_session.is_authenticated = True
+        order_id = "D01-9262519-8073835"
+        with open(
+            os.path.join(
+                self.RESOURCES_DIR, "orders", f"order-summary-{order_id}.html"
+            ),
+            "r",
+            encoding="utf-8",
+        ) as f:
+            resp1 = responses.add(
+                responses.GET,
+                f"{self.test_config.constants.ORDER_DETAILS_URL}?orderID={order_id}",
+                body=f.read(),
+                status=200,
+            )
+
+        # WHEN
+        order = self.amazon_orders.get_order(order_id)
+
+        # THEN
+        self.assert_order_D01_9262519_8073835_digital_order_rd(order, True)
+        self.assertIsNone(order.index)
+        self.assertEqual(1, resp1.call_count)
+
+    @responses.activate
     def test_get_order_2024_data_component_subscription(self):
         # GIVEN
         self.amazon_session.is_authenticated = True

--- a/tests/testcase.py
+++ b/tests/testcase.py
@@ -447,6 +447,18 @@ class TestCase(unittest.TestCase):
 
         # We cannot parse full details for digital orders, so nothing to assert
 
+    def assert_order_D01_9262519_8073835_digital_order_rd(self, order, full_details=False):
+        self.assertEqual("D01-9262519-8073835", order.order_id)
+        self.assertEqual(14.99, order.grand_total)
+        self.assertIsNotNone(order.order_details_link)
+        self.assertEqual(date(2024, 9, 20), order.order_date)
+        self.assertEqual(0, len(order.shipments))
+        self.assertEqual(0, len(order.items))
+
+        self.assertEqual(order.full_details, full_details)
+
+        # We cannot parse full details for digital orders, so nothing to assert
+
     def assert_order_114_8722141_6545058_data_component_subscription(self, order, full_details=False):
         self.assertEqual("114-8722141-6545058", order.order_id)
         self.assertEqual(44.46, order.grand_total)

--- a/tests/unittestcase.py
+++ b/tests/unittestcase.py
@@ -71,10 +71,22 @@ class UnitTestCase(TestCase):
             "password": "some-password",
             "rememberMe": "true"
         }
-        with open(os.path.join(self.RESOURCES_DIR, "orders", "order-history-2018-0.html"), "r", encoding="utf-8") as f:
+        with open(
+            os.path.join(self.RESOURCES_DIR, "orders", "order-history-2018-0.html"),
+            "r",
+            encoding="utf-8",
+        ) as f:
             self.authenticated_response = responses.add(
                 responses.POST,
                 self.test_config.constants.SIGN_IN_URL,
+                body=f.read(),
+                status=200,
+                match=[urlencoded_params_matcher(request_data)],
+            )
+            # Some auth pages post to amazon.com, so mock that as well
+            responses.add(
+                responses.POST,
+                "https://www.amazon.com/ap/signin",
                 body=f.read(),
                 status=200,
                 match=[urlencoded_params_matcher(request_data)],
@@ -90,6 +102,16 @@ class UnitTestCase(TestCase):
                 "{optional_start_index}".format(url=self.test_config.constants.ORDER_HISTORY_URL,
                                                 year=year,
                                                 optional_start_index=optional_start_index),
+                body=f.read(),
+                status=200,
+            )
+
+    def given_transactions_exists(self):
+        with open(os.path.join(self.RESOURCES_DIR, "transactions", "get-transactions-snippet.html"), "r",
+                  encoding="utf-8") as f:
+            return responses.add(
+                responses.POST,
+                f"{self.test_config.constants.TRANSACTION_HISTORY_URL}",
                 body=f.read(),
                 status=200,
             )


### PR DESCRIPTION
## Summary
- attach `Order` details directly to each `Transaction`
- drive history command off transactions and write `transactions-{year}.csv`
- update transaction command to populate each transaction's order data
- show payment date when printing order details
- allow auth POSTs to amazon.com in tests

## Testing
- `pytest -q` *(fails: 27 failed, 34 passed, 9 skipped, 6 errors)*

------
https://chatgpt.com/codex/tasks/task_b_68487d458ee88330afed492bde4c3cdf