### PR TITLE
Fix shipping discount parsing

### DIFF
--- a/amazonorders/entity/order.py
+++ b/amazonorders/entity/order.py
@@ -111,7 +111,9 @@ class Order(Parsable):
         self.shipping_total: Optional[float] = self._if_full_details(self._parse_currency("shipping")) or 0.0
         #: The Order free shipping. Only populated when ``full_details`` is ``True``.
         self.free_shipping: Optional[float] = self._if_full_details(self._parse_currency("free shipping")) or 0.0
-        self.item_shipping_and_handling: Optional[float] = (self.shipping_total or 0.0) - (self.free_shipping or 0.0)
+        self.item_shipping_and_handling: Optional[float] = (
+            (self.shipping_total or 0.0) + (self.free_shipping or 0.0)
+        )
         #: The Order promotion applied. Only populated when ``full_details`` is ``True``.
         self.promotion: float = self._if_full_details(
             self._parse_currency("promotion", combine_multiple=True)) or 0.0

--- a/tests/test_orders.py
+++ b/tests/test_orders.py
@@ -626,6 +626,66 @@ class TestOrders(UnitTestCase):
         self.assert_order_702_9503699_0712205(order, True)
         self.assertIsNone(order.index)
         self.assertEqual(1, resp1.call_count)
+
+    @responses.activate
+    def test_get_order_702_7200239_3881040(self):
+        self.amazon_session.is_authenticated = True
+        order_id = "702-7200239-3881040"
+        with open(
+            os.path.join(self.RESOURCES_DIR, "orders", "2024", f"order-details-{order_id}.html"),
+            "r",
+            encoding="utf-8",
+        ) as f:
+            resp1 = responses.add(
+                responses.GET,
+                f"{self.test_config.constants.ORDER_DETAILS_URL}?orderID={order_id}",
+                body=f.read(),
+                status=200,
+            )
+        order = self.amazon_orders.get_order(order_id)
+        self.assert_order_702_7200239_3881040(order, True)
+        self.assertIsNone(order.index)
+        self.assertEqual(1, resp1.call_count)
+
+    @responses.activate
+    def test_get_order_702_7633140_4494667(self):
+        self.amazon_session.is_authenticated = True
+        order_id = "702-7633140-4494667"
+        with open(
+            os.path.join(self.RESOURCES_DIR, "orders", "2024", f"order-details-{order_id}.html"),
+            "r",
+            encoding="utf-8",
+        ) as f:
+            resp1 = responses.add(
+                responses.GET,
+                f"{self.test_config.constants.ORDER_DETAILS_URL}?orderID={order_id}",
+                body=f.read(),
+                status=200,
+            )
+        order = self.amazon_orders.get_order(order_id)
+        self.assert_order_702_7633140_4494667(order, True)
+        self.assertIsNone(order.index)
+        self.assertEqual(1, resp1.call_count)
+
+    @responses.activate
+    def test_get_order_702_8836580_6196229(self):
+        self.amazon_session.is_authenticated = True
+        order_id = "702-8836580-6196229"
+        with open(
+            os.path.join(self.RESOURCES_DIR, "orders", "2024", f"order-details-{order_id}.html"),
+            "r",
+            encoding="utf-8",
+        ) as f:
+            resp1 = responses.add(
+                responses.GET,
+                f"{self.test_config.constants.ORDER_DETAILS_URL}?orderID={order_id}",
+                body=f.read(),
+                status=200,
+            )
+        order = self.amazon_orders.get_order(order_id)
+        self.assert_order_702_8836580_6196229(order, True)
+        self.assertIsNone(order.index)
+        self.assertEqual(1, resp1.call_count)
     @unittest.skipIf(not os.path.exists(temp_order_history_file_path),
                      reason="Skipped, to debug an order history page, "
                             "place it at tests/output/temp-order-history.html")

--- a/tests/testcase.py
+++ b/tests/testcase.py
@@ -732,10 +732,77 @@ class TestCase(unittest.TestCase):
             self.assertEqual("Mastercard", order.payment_method)
             self.assertEqual(1301, order.payment_method_last_4)
             self.assertEqual(34.79, order.item_subtotal)
-            self.assertEqual(13.98, order.item_shipping_and_handling)
+            self.assertEqual(0.00, order.item_shipping_and_handling)
             self.assertEqual(33.05, order.total_before_tax)
             self.assertEqual(4.27, order.item_federal_tax)
             self.assertEqual(4.97, order.items[0].price)
+
+    def assert_order_702_7200239_3881040(self, order, full_details=False):
+        self.assertEqual("702-7200239-3881040", order.order_id)
+        self.assertEqual(67.79, order.grand_total)
+        self.assertIsNotNone(order.order_details_link)
+        self.assertEqual(date(2024, 2, 2), order.order_date)
+        self.assertEqual("Pooja Jain", order.recipient.name)
+        self.assertEqual(1, len(order.shipments))
+        self.assertEqual(str(order.items), str(order.shipments[0].items))
+        self.assertEqual(1, len(order.items))
+        self.assertTrue(order.items[0].title.startswith("Capri Tools 21050"))
+
+        self.assertEqual(order.full_details, full_details)
+
+        if full_details:
+            self.assertEqual("Mastercard", order.payment_method)
+            self.assertEqual(1301, order.payment_method_last_4)
+            self.assertEqual(59.99, order.item_subtotal)
+            self.assertEqual(0.00, order.item_shipping_and_handling)
+            self.assertEqual(59.99, order.total_before_tax)
+            self.assertEqual(7.80, order.item_federal_tax)
+            self.assertEqual(59.99, order.items[0].price)
+
+    def assert_order_702_7633140_4494667(self, order, full_details=False):
+        self.assertEqual("702-7633140-4494667", order.order_id)
+        self.assertEqual(43.02, order.grand_total)
+        self.assertIsNotNone(order.order_details_link)
+        self.assertEqual(date(2024, 2, 2), order.order_date)
+        self.assertEqual("Pooja Jain", order.recipient.name)
+        self.assertEqual(1, len(order.shipments))
+        self.assertEqual(str(order.items), str(order.shipments[0].items))
+        self.assertEqual(2, len(order.items))
+        self.assertTrue(order.items[0].title.startswith("Gorilla High Performance"))
+
+        self.assertEqual(order.full_details, full_details)
+
+        if full_details:
+            self.assertEqual("Mastercard", order.payment_method)
+            self.assertEqual(1301, order.payment_method_last_4)
+            self.assertEqual(38.07, order.item_subtotal)
+            self.assertEqual(0.00, order.item_shipping_and_handling)
+            self.assertEqual(38.07, order.total_before_tax)
+            self.assertEqual(4.95, order.item_federal_tax)
+            self.assertEqual(14.54, order.items[0].price)
+            self.assertEqual(8.99, order.items[1].price)
+
+    def assert_order_702_8836580_6196229(self, order, full_details=False):
+        self.assertEqual("702-8836580-6196229", order.order_id)
+        self.assertEqual(56.49, order.grand_total)
+        self.assertIsNotNone(order.order_details_link)
+        self.assertEqual(date(2023, 12, 15), order.order_date)
+        self.assertEqual("Pooja Jain", order.recipient.name)
+        self.assertEqual(1, len(order.shipments))
+        self.assertEqual(str(order.items), str(order.shipments[0].items))
+        self.assertEqual(1, len(order.items))
+        self.assertTrue(order.items[0].title.startswith("JASAMBAC Cocktail Dress"))
+
+        self.assertEqual(order.full_details, full_details)
+
+        if full_details:
+            self.assertEqual("Mastercard", order.payment_method)
+            self.assertEqual(1301, order.payment_method_last_4)
+            self.assertEqual(49.99, order.item_subtotal)
+            self.assertEqual(0.00, order.item_shipping_and_handling)
+            self.assertEqual(49.99, order.total_before_tax)
+            self.assertEqual(6.50, order.item_federal_tax)
+            self.assertEqual(49.99, order.items[0].price)
 
 
 


### PR DESCRIPTION
## Summary
- handle free shipping discounts when calculating Shipping & Handling
- test shipping discount parsing for new orders

## Testing
- `pytest -q` *(fails: Connection refused by Responses - the call doesn't match any registered mock)*

------
https://chatgpt.com/codex/tasks/task_b_684e0c60d22c83308bec3eb1bb5b5c27